### PR TITLE
Add rich to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ if __name__ == '__main__':
             'matplotlib',
             'astropy>=3.1',
             'healpy>=1.12.4',
-            'cartopy'
+            'cartopy',
+            'rich'
         ],
         extras_require={
             'docs': [


### PR DESCRIPTION
pytest fails on heasarc.py because the rich package was not installed.