### PR TITLE
Import fixes to gdt-data and documentation

### DIFF
--- a/PYPI-README.rst
+++ b/PYPI-README.rst
@@ -21,9 +21,9 @@ If you don't plan to contribute code to the project, the recommended install met
 .. code-block:: sh
 
    pip install astro-gdt
-   gdt data init
+   gdt-data init
 
-The ``gdt data init`` is required to initialize the library after installation.
+The ``gdt-data init`` is required to initialize the library after installation.
 
 
 Contributing Code or Documentation

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ If you don't plan to contribute code to the project, the recommended install met
    pip install astro-gdt
    gdt-data init
 
-The ``gdt data init`` is required to initialize the library after installation.
+The ``gdt-data init`` is required to initialize the library after installation.
 
 
 Setting up a development environment

--- a/scripts/gdt-data
+++ b/scripts/gdt-data
@@ -30,13 +30,18 @@
 import argparse
 import shutil
 from urllib.parse import urlparse
-from importlib.resources import files
-
-import os
 from pathlib import Path
 from typing import List
+
+# Use the backport version if importlib.resources for Python earlier than 3.10
+import sys
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
 from gdt.core import data_path
-from gdt.core.heasarc import FileDownloader
+
 
 gdt_data = files('gdt.data')
 

--- a/scripts/gdt-data
+++ b/scripts/gdt-data
@@ -41,7 +41,7 @@ else:
     from importlib.resources import files
 
 from gdt.core import data_path
-
+from gdt.core.heasarc import FileDownloader
 
 gdt_data = files('gdt.data')
 

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,9 @@ if __name__ == '__main__':
                 'astro-gdt-fermi',
             ]
         },
+        project_urls={
+            'Documentation': 'https://astro-gdt.readthedocs.io/en/latest/',
+            'Source': 'https://github.com/USRA-STI/gdt-core',
+            'Tracker': 'https://github.com/USRA-STI/gdt-core/issues',
+        }
     )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
         package_dir={"": "src"},
         python_requires='>=3.8',
         install_requires=[
-            'importlib-resources;python_version<"3.9"',
+            'importlib-resources;python_version<"3.10"',
             'pyproj>=1.9.6',
             'numpy>=1.17.3',
             'scipy>=1.1.0',

--- a/src/gdt/core/__init__.py
+++ b/src/gdt/core/__init__.py
@@ -29,7 +29,7 @@
 import os
 from pathlib import Path
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 suite_path = Path(__file__).parent.parent
 


### PR DESCRIPTION
This fixes some issues found after release.  

- importlib.resources is imported as importlib_resources in python versions less than 3.10
- documentation was modified to include acknowledgements and fix some install instructions