### PR TITLE
Fix bug preventing a copy by accepting cards like fits.Header

### DIFF
--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -53,7 +53,7 @@ class Header(fits.Header):
     Once initialized, the class behaves as any other astropy.io.fits.Header, 
     however, new keywords cannot be added after initialization.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, cards = [], *args, **kwargs):
         
         # an extension name must be set
         if not hasattr(self, 'name'):
@@ -70,7 +70,15 @@ class Header(fits.Header):
         for keyword in self.keywords:
             self.append(keyword)
         self.keywords = None
-        
+
+        if isinstance(cards, fits.Header):
+            cards = cards.cards
+        elif isinstance(cards, dict):
+            cards = cards.items()
+
+        for card in cards:
+            self[card[0]] = card[1]
+
         for key, val in kwargs.items():
             self[key] = val
  


### PR DESCRIPTION
The [copy()](https://github.com/astropy/astropy/blob/d2f55ce76bdf0b56a0424509fd43bf0095f9c5b7/astropy/io/fits/header.py#L827) method for a header expects the same [__init__](https://github.com/astropy/astropy/blob/d2f55ce76bdf0b56a0424509fd43bf0095f9c5b7/astropy/io/fits/header.py#L96) signature as the parent. Since the current Header class in GDT does not take as first argument the `cards` parameters, the value are never copied, and instead you get the defaults from .keywords.