### PR TITLE
Make DataCollection more pythonic with [] access

### DIFF
--- a/src/gdt/core/collection.py
+++ b/src/gdt/core/collection.py
@@ -154,6 +154,12 @@ class DataCollection():
             except AttributeError:
                 self._data_dict['item{}'.format(len(self) + 1)] = data_item
 
+    def __getitem__(self, key):
+        return self.get_item(key)
+
+    def __setitem__(self, key, value):
+        self.include(value, key)
+    
     def remove(self, item_name):
         """Remove an object from the collection given the name 
         


### PR DESCRIPTION
DataCollection is an obvious dict wrapper. In my opinion, it should behave like one. This will make the code more intuitive.

I added [] functionality, a wrapper for get_item() and include().

I was planning to also add keys(), values() and items(), but unfortunately that crashes with the items property, which actually returns the keys (so not very intuitive). Should we change that? 