### PR TITLE
Add ebounds setter

### DIFF
--- a/src/gdt/core/data_primitives.py
+++ b/src/gdt/core/data_primitives.py
@@ -506,10 +506,7 @@ class EventList():
                                 dtype=[('TIME', times.dtype.type),
                                        ('PHA', channels.dtype.type)])
         
-        if ebounds is not None:
-            if not isinstance(ebounds, Ebounds):
-                raise TypeError('ebounds must be of type Ebounds')
-        self._ebounds = ebounds
+        self.ebounds = ebounds
         
     @property
     def channel_range(self):
@@ -526,7 +523,15 @@ class EventList():
     def ebounds(self):
         """(:class:`Ebounds`): The energy bounds of the energy channels"""
         return self._ebounds
-    
+
+    @ebounds.setter
+    def ebounds(self, ebounds):
+        """(:class:`Ebounds`): The energy bounds of the energy channels"""
+        if ebounds is not None and not isinstance(ebounds, Ebounds):
+                raise TypeError('ebounds must be of type Ebounds or None')
+
+        self._ebounds = ebounds
+        
     @property
     def emax(self):
         """(float): The maximum energy"""

--- a/src/gdt/core/tte.py
+++ b/src/gdt/core/tte.py
@@ -58,6 +58,11 @@ class PhotonList(FitsFileContextManager):
         """(:class:`~.data_primitives.Ebounds`): The energy-channel mapping"""
         return self.data.ebounds
 
+    @ebounds.setter
+    def ebounds(self, ebounds):
+        """(:class:`~.data_primitives.Ebounds`): The energy-channel mapping"""
+        self.data.ebounds = ebounds
+
     @property
     def energy_range(self):
         """(float, float): The energy range of the data"""


### PR DESCRIPTION
This is particularly useful for BurstCube, since we have the EBOUNDS information as a separate file, not in the TTE HDUs. This way we can load the TTE file and then "calibrate" appropriately based on the TTE header information.