### PR TITLE
Add support for opening FITS files with `fsspec`

### DIFF
--- a/src/gdt/core/file.py
+++ b/src/gdt/core/file.py
@@ -133,21 +133,25 @@ class FitsFileContextManager(AbstractContextManager):
             return ()
 
     @classmethod
-    def open(cls, file_path: Union[str, Path], mode: str = 'readonly', memmap: bool = None):
+    def open(cls, file_path: Union[str, Path], mode: str = 'readonly', memmap: bool = None, use_fsspec: bool = False, fsspec_kwargs: dict = None):
         """Open a FITS file.
             
         Args:
             file_path (str): The file path
             mode (str): The file access mode
             memmap (bool): If True, memory map when reading the file
+            use_fsspec (bool): Use `fsspec.open` to open the file, Defaults to `False`. Use of this feature requires the optional
+                ``fsspec`` package. A ``ModuleNotFoundError`` will be raised if the dependency is missing.
+            fsspec_kwargs (dict): Keyword arguments passed on to `fsspec.open`. This can be used to
+                configure local caching using, for example, simplecache.
         
         Returns:
             (:class:`FitsFileContextManager`)
         """
-        path = Path(file_path)
+        path = Path(file_path) if not use_fsspec else file_path
         obj = cls()
-        obj._hdulist = fits.open(path, mode=mode, memmap=memmap)
-        obj._filename = path.name
+        obj._hdulist = fits.open(path, mode=mode, memmap=memmap, use_fsspec=use_fsspec, fsspec_kwargs=fsspec_kwargs)
+        obj._filename = path.name if not use_fsspec else file_path
         return obj
 
     def write(self, directory: Union[str, Path], filename: str = None, **kwargs):

--- a/tests/core/test_file.py
+++ b/tests/core/test_file.py
@@ -31,6 +31,7 @@ import unittest
 import numpy as np
 from tempfile import TemporaryDirectory, mkdtemp
 from pathlib import Path
+import pytest
 from astropy.io import fits
 from gdt.core.file import FileContextManager, FitsFileContextManager
 
@@ -169,3 +170,25 @@ class TestFitsFileContextManager(unittest.TestCase):
 
             fpath = Path(this_path, self.fits_file.name)
             self.assertTrue(fpath.exists())
+
+
+@pytest.fixture(scope="module")
+def cache_path():
+    return mkdtemp()
+
+
+@pytest.mark.parametrize("fits_file", ["tcat", "trigdat"])
+def test_fsspec_cache_open_fits(fits_file, cache_path):
+    trigger_name = "bn190915240"
+    file_name = f"glg_{fits_file}_all_{trigger_name}_v0[0-9].fit"
+    fits_url = f"simplecache::https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/20{trigger_name[2:4]}/{trigger_name}/current/{file_name}"
+    fsspec_kwargs = {"simplecache": {"cache_storage": cache_path, "same_names": True}}
+    with FitsFileContextManager.open(fits_url, use_fsspec=True, fsspec_kwargs=fsspec_kwargs) as f:
+        assert f is not None
+        assert f.num_hdus >= 1
+        assert f.hdulist[0].name
+        assert f.hdulist[0].header
+        assert len(f.hdulist[0].header.cards) >= 1
+        assert next(Path(cache_path).glob(file_name))
+
+


### PR DESCRIPTION
`gdt.core.file.FitsFileContextManager` uses `astropy.io.fits.open()` to open local FITS files. This PR adds support for using [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) to open FITS files stored remotely, removing the requirement for prior FITS retrieval and local storage, while also automatically caching the files if required. This is achieved with the [`use_fsspec` and `fsspec_kwargs` parameters supported by `astropy.io.fits.open()`](https://docs.astropy.org/en/stable/io/fits/usage/cloud.html)

A couple of test cases have been added that use `fsspec` to open and cache GBM catalog FITS files.