### PR TITLE
Fix exposure calculation to account for edge effects and GTI

### DIFF
--- a/src/gdt/core/data_primitives.py
+++ b/src/gdt/core/data_primitives.py
@@ -640,7 +640,7 @@ class EventList():
         overflow_counts = counts[:, -1]
         deadtime = counts.sum(axis=1) * event_deadtime + \
                    overflow_counts * (overflow_deadtime - event_deadtime)
-        exposure = (hi_edges - lo_edges) - deadtime
+        exposure = (np.minimum(hi_edges, tstop) - np.maximum(lo_edges, tstart)) - deadtime
         
         if self.ebounds is None:
             bins = TimeChannelBins(counts, lo_edges, hi_edges, exposure,

--- a/src/gdt/core/tte.py
+++ b/src/gdt/core/tte.py
@@ -331,6 +331,12 @@ class PhotonList(FitsFileContextManager):
             obj = obj.slice_time(time_range)
 
         # do the time binning to create the TimeEnergyBins or TimeChannelBins
+        # Use GTI start tstart/tstop by default
+        if 'tstart' not in kwargs:
+            kwargs['tstart'] = self.gti[0].tstart 
+        if 'tstop' not in kwargs:
+            kwargs['tstop'] = self.gti[-1].tstop
+        
         bins = obj.data.bin(bin_method, *args, **kwargs)
         if (energy_range is not None) and (self.ebounds is not None):
             bins = bins.slice_energy(*energy_range)


### PR DESCRIPTION
The first and last time bins didn't have a correct exposure due to edge effects and not accounting for the GTI. There were 2 issues:

1. When using `time_ref`, the first/last edge could go before/beyond the beginning/end of the TTE time range. This is time for which there is no data but it was still counted as part of the exposure.
2. The tstart/tstop times corresponded to the first/last event. If you have large statistics this is not really an issue, but once you have low statistics --e.g. you cut in energy first-- then the exposure would be underestimated. 


e.g. 
```
from gdt.missions.fermi.gbm.tte import GbmTte
from gdt.core.binning.unbinned import bin_by_time

filename,_ = urllib.request.urlretrieve("https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2021/bn210925800/current/glg_tte_n6_bn210925800_v00.fit")
    
tte = GbmTte.open(filename)

phaii = tte.to_phaii(bin_by_time, 0.032, time_ref=0.0)
```

Before this change would return
```
$ phaii.data.exposure[:5]
array([0.0319974, 0.031889 , 0.0318864, 0.0318812, 0.0319202])
```

Where the rate of the first bin is artificially too small

And after:
```
$ phaii.data.exposure[:5]
array([0.00172335, 0.031889  , 0.0318864 , 0.0318812 , 0.0319202 ])
```



I know I need to write a test for this and the other open PR. However since these are changes that we'll use for the Burstcube pipeline (we're using the fork https://github.com/BurstCube/gdt-core), I thought it would be better the open the PR sooner than later so people are aware.