### PR TITLE
Headers warning

### DIFF
--- a/docs/core/headers.rst
+++ b/docs/core/headers.rst
@@ -170,10 +170,10 @@ update the value to the current date and time:
   '2022-04-23T17:11:05'
 
 The FileHeaders class can act as a header verifier for reading in files. If 
-there are missing keywords compared to what is expected in the header template,
-or if the values are not the type expected, an exception will be raised. If 
-there are extraneous keywords in the header compared to what is expected, no
-exception will be raised, but the extraneous keywords will be ignored.
+there are missing keywords compared to what is expected in the header template, 
+a warning will be raised. If there are extraneous keywords in the header 
+compared to what is expected, no warning will be raised, but the extraneous 
+keywords will be ignored.
 
 To test this, let's make a similar header to ``MyHeader``, but with the ``BOOL``
 keyword missing:
@@ -190,7 +190,7 @@ will populate the template headers with the header information:
 
   >>> # the list of headers can be from a file read from disk
   >>> file_headers = MyFileHeaders.from_headers([MyPartialHeader(), MySecondHeader()])
-  KeyError: "Keyword 'BOOL' not found."
+  RuntimeWarning: BOOL not found in header PRIMARY
   >>> file_headers = MyFileHeaders.from_headers([MyHeader(), MySecondHeader()])
   >>> file_headers
   <MyFileHeaders: 2 headers>

--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -183,18 +183,27 @@ class FileHeaders():
             hidx = 0
             for key in obj[i].keys():
                 if (key == 'COMMENT'):
-                    obj[i][key][cidx] = headers[i][key][cidx]
-                    cidx += 1
+                    try:
+                        obj[i][key][cidx] = headers[i][key][cidx]
+                        cidx += 1
+                    except KeyError:
+                        warnings.warn(f'{key} not found in header {obj[i].name}', 
+                                      RuntimeWarning, stacklevel=2)      
+                        
                 elif (key == 'HISTORY'):
-                    obj[i][key][hidx] = headers[i][key][hidx]
-                    hidx += 1
+                    try:
+                        obj[i][key][hidx] = headers[i][key][hidx]
+                        hidx += 1
+                    except KeyError:
+                        warnings.warn(f'{key} not found in header {obj[i].name}', 
+                                      RuntimeWarning, stacklevel=2)      
+
                 else:
                     try:
                         obj[i][key] = headers[i][key]
                     except KeyError:
                         warnings.warn(f'{key} not found in header {obj[i].name}', 
-                                      RuntimeWarning, stacklevel=2)
-                        
+                                      RuntimeWarning, stacklevel=2)      
         
         return obj
         

--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -26,6 +26,7 @@
 # implied. See the License for the specific language governing permissions and limitations under the
 # License.
 #
+import warnings
 import astropy.io.fits as fits
 from astropy.time import Time
 
@@ -188,7 +189,12 @@ class FileHeaders():
                     obj[i][key][hidx] = headers[i][key][hidx]
                     hidx += 1
                 else:
-                    obj[i][key] = headers[i][key]
+                    try:
+                        obj[i][key] = headers[i][key]
+                    except:
+                        warnings.warn(f'{key} not found in header', 
+                                      RuntimeWarning)
+                        
         
         return obj
         

--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -191,7 +191,7 @@ class FileHeaders():
                 else:
                     try:
                         obj[i][key] = headers[i][key]
-                    except:
+                    except KeyError:
                         warnings.warn(f'{key} not found in header', 
                                       RuntimeWarning)
                         

--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -192,8 +192,8 @@ class FileHeaders():
                     try:
                         obj[i][key] = headers[i][key]
                     except KeyError:
-                        warnings.warn(f'{key} not found in header', 
-                                      RuntimeWarning)
+                        warnings.warn(f'{key} not found in header {obj[i].name}', 
+                                      RuntimeWarning, stacklevel=2)
                         
         
         return obj

--- a/tests/core/test_headers.py
+++ b/tests/core/test_headers.py
@@ -27,6 +27,7 @@
 # License.
 #
 import unittest
+import warnings
 from gdt.core.headers import Header, FileHeaders
 
 # classes for unit tests
@@ -191,6 +192,11 @@ class TestFileHeaders(unittest.TestCase):
         # wrong number of headers
         with self.assertRaises(ValueError):
              MyFileHeaders.from_headers([MyHeader()])
+        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            MyFileHeaders.from_headers([MyHeader(), MyHeader()])
+            assert len(w) == 3
 
     def test_creator(self):
         creator = self.headers.creator()


### PR DESCRIPTION
Currently, when FileHeaders.from_headers() is given a list of headers, it will raise an exception if a keyword is missing in the any of the headers in the list.  The change here is to raise a RuntimeWarning instead of an exception.  This will alert the user that there is metadata that is missing from what is expected, but the issue, in general, is not critical enough to warrant an exception and population of the FileHeaders object should continue.

In many cases, the header information for a mission evolves over time, and raising an exception essentially prevents the user from working with data that has metadata that does not perfectly conform to the expected content. I consider this a bug because incomplete, or even slightly different metadata, should not prevent a user from using the data.