### PR TITLE
Improve PG-stat stability

### DIFF
--- a/tests/core/spectra/test_fitting.py
+++ b/tests/core/spectra/test_fitting.py
@@ -929,7 +929,8 @@ class TestSpectralFitterPgstat(unittest.TestCase):
         self.rsp2 = make_rsp('det1')
         self.fitter = SpectralFitterPgstat([self.pha1, self.pha2],
                                            [self.bak1.data, self.bak2.data],
-                                           [self.rsp1, self.rsp2], method='TNC')
+                                           [self.rsp1, self.rsp2], 
+                                           method='Nelder-Mead')
         pl = PowerLaw()
         pl.max_values[1] = 10.0
         self.fitter.fit(pl)


### PR DESCRIPTION
The stability of PG-stat is improved and made more efficient.  The derivation noted in the [Appendix B](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html) of the XSPEC manual has been updated to clarify how to handle certain scenarios, particularly when to use the positive and negative roots of the quadratic solution when maximizing the likelihood of the background model rate in each channel. See equation B.17 and the line after equation B.18. These improvements have been implemented.

Additionally, a bug was fixed that particularly impacted situations where the exposure is << 1.  Specifically, the background *rate* variance was being used to calculate PG-stat (see [here](https://github.com/USRA-STI/gdt-core/blob/018acb32c52c1f5571d3e66770156b43a365facb/src/gdt/core/spectra/fitting.py#L979)) when the background *count* variance should be used.