### PR TITLE
Ensure FitsFileContextManager._repr_html_ runs when used with GbmHealPix.open

### DIFF
--- a/src/gdt/core/file.py
+++ b/src/gdt/core/file.py
@@ -207,7 +207,7 @@ class FitsFileContextManager(AbstractContextManager):
         s = f'<p>&lt{self.__class__.__name__}(filename=<b>"{self.filename}"</b>) at {hex(id(self))}&gt</p>'
         s += '<table>'
         s += '<tr><th>No.</th><th>Name</th><th>Ver</th><th>Type</th><th>Cards</th><th>Dimensions</th></tr>'
-        for row in self._hdulist.info(False):
+        for row in self.hdulist.info(False):
             s += f'<tr><td>{row[0]}</td><td>{row[1]}</td><td>{row[2]}</td><td>{row[3]}</td><td>{row[4]}</td>' \
                  f'<td>{row[5]}</td></tr>'
         s += '</table>'


### PR DESCRIPTION
As previously discussed, this fixes the `gdt-fermi` issue: https://github.com/USRA-STI/gdt-fermi/issues/15

A test case using a GBM localization will be provided separately in the `gdt-fermi` repo.