### PR TITLE
Fix for SuperFunction `names` attribute

### DIFF
--- a/src/gdt/core/spectra/functions.py
+++ b/src/gdt/core/spectra/functions.py
@@ -256,8 +256,13 @@ class Function(ABC):
             (:class:`SuperFunction`)
         """
         obj = cls._super_function(func1, func2, np.sum)
-        obj.names = [func1.name, func2.name]
-        obj.name = ' + '.join(obj.names)
+        if isinstance(func1, SuperFunction):
+            obj.names = func1.names + [func2.name]
+        elif isinstance(func2, SuperFunction):
+            obj.names = func2.names + [func1.name]
+        else:
+            obj.names = [func1.name, func2.name]        
+        obj.name = ' + '.join([func1.name, func2.name])
         return obj
 
     @classmethod
@@ -272,8 +277,13 @@ class Function(ABC):
             (:class:`SuperFunction`)
         """
         obj = cls._super_function(func1, func2, np.prod)
-        obj.names = [func1.name, func2.name]
-        obj.name = ' * '.join(obj.names)
+        if isinstance(func1, SuperFunction):
+            obj.names = func1.names + [func2.name]
+        elif isinstance(func2, SuperFunction):
+            obj.names = func2.names + [func1.name]
+        else:
+            obj.names = [func1.name, func2.name]   
+        obj.name = ' * '.join([func1.name, func2.name])
         return obj
 
     @classmethod

--- a/tests/core/spectra/test_functions.py
+++ b/tests/core/spectra/test_functions.py
@@ -155,6 +155,7 @@ class TestAdditiveSuperFunction(unittest.TestCase):
                           ('MySecondFunction: C0', 'units1', 'Coeff1'),
                           ('MySecondFunction: C1', 'units2', 'Coeff2')])
         self.assertEqual(myfunc.free, [True] * 4)
+        assert myfunc.names == ['MyFirstFunction', 'MySecondFunction']
 
     def test_eval(self):
         myfunc = MyFirstFunction() + MySecondFunction()
@@ -181,6 +182,7 @@ class TestMultiplicativeSuperFunction(unittest.TestCase):
                           ('MySecondFunction: C0', 'units1', 'Coeff1'),
                           ('MySecondFunction: C1', 'units2', 'Coeff2')])
         self.assertEqual(myfunc.free, [True] * 4)
+        assert myfunc.names == ['MyFirstFunction', 'MySecondFunction']
 
     def test_eval(self):
         myfunc = MyFirstFunction() * MySecondFunction()
@@ -200,6 +202,8 @@ class TestMixedMultipleSuperFunctions(unittest.TestCase):
         self.assertEqual(myfunc.name, 'MyFirstFunction + MySecondFunction * MyThirdFunction')
         self.assertEqual(myfunc.nparams, 5)
         self.assertEqual(myfunc.num_components, 3)
+        assert myfunc.names == ['MyFirstFunction', 'MySecondFunction', 
+                                'MyThirdFunction']
 
     def test_eval(self):
         myfunc = MyFirstFunction() + MySecondFunction() * MyThirdFunction()


### PR DESCRIPTION
Fix for Issue #34.

The `names` attribute now properly updates when combining multiple functions into a super function.  Previously, if more than two functions were combined, the `SuperFunction.name` attribute was used, which combines the individual function names.  For example, this would result in `len(SuperFunction.names) == 2` when three functions were combined. 

Now, each function `name` attribute is tracked and appended to the `names` list, resulting in `len(SuperFunction.names) == 3` when three functions are combined.

Unit tests updated to confirm that `names` returns the expected list.