### PR TITLE
Skyplot heatmap fix

### DIFF
--- a/src/gdt/core/plot/lib.py
+++ b/src/gdt/core/plot/lib.py
@@ -934,14 +934,23 @@ def sky_heatmap(x, y, heatmap, ax, cmap='RdPu', norm=None, flipped=True,
     
     if frame == 'spacecraft':
         flipped = False
-        phi1 = phi - np.pi
+        
+        # plots from azimuth (0, +180)
+        phi1 = phi + np.pi
+        phi1_mask = phi1 > np.pi
+        phi1[phi1_mask] = 2.0*np.pi - phi1[phi1_mask]
         image1 = ax.pcolormesh(phi1, theta, heatmap, rasterized=True, cmap=cmap,
                                norm=norm)
         
-        phi2 = phi + np.pi
+        # plots from azimuth (-180, 0)
+        phi2 = phi - np.pi
+        phi2_mask = phi2 < -np.pi
+        phi2[phi2_mask] = 2.0*np.pi + phi2[phi2_mask]
+
         image2 = ax.pcolormesh(phi2, theta, heatmap, rasterized=True, cmap=cmap,
                                norm=norm)
         return [image1, image2]
+    
     elif frame == 'galactic':
         phi1 = phi - np.pi
         if flipped:

--- a/src/gdt/core/plot/sky.py
+++ b/src/gdt/core/plot/sky.py
@@ -453,6 +453,12 @@ class SkyPlot(GdtPlot):
         else:
             x = lon_array
             y = lat_array
+        
+        # Astropy SkyCoord will convert 360 deg to 0 deg, which results in 
+        # undesired behavior for plotting.  So, we make this a value slightly
+        # smaller than 360 deg.        
+        x[(x == 360.0)] = (360.0 - 1e-6)
+
         coords = SkyCoord(x.flatten(), y.flatten(), frame='gcrs', unit='deg')
         
         try:


### PR DESCRIPTION
This implements a generic fix for Issue #17.  Since SkyCoord wraps RA=360 to be RA=0, this causes a plotting artifact for heatmaps that cross the meridian.  The solution in this PR is to move values of RA that are identically == 360 to be a small epsilon less than 360, which eliminates the artifact regardless of whether one is plotting in equatorial, galactic or spacecraft coordinates.

Fixed EquatorialPlot:
![equatorial](https://github.com/USRA-STI/gdt-core/assets/129613567/cedd58b7-44d7-4ddf-b3b9-581b6a4768d7)

Fixed GalacticPlot:
![galactic](https://github.com/USRA-STI/gdt-core/assets/129613567/197c6816-1d46-4768-9d1c-5ac5ceac9ee6)


While testing this solution, I discovered a separate wrapping issue that affected the plotting of the heatmap for `SpacecraftPlot`:
![spacecraft_bad](https://github.com/USRA-STI/gdt-core/assets/129613567/37a2d3f2-7c43-4a1a-b86e-0ab55eb8da8e)

This is caused by incorrectly shifting the azimuth array.  The implemented fix performs two shifts (and thereby makes two heatmaps), one shift of +180 and the other of -180, and correctly wraps the azimuth array in both directions.  Here is the plot after the fix is implemented:
![spacecraft_good](https://github.com/USRA-STI/gdt-core/assets/129613567/de916a6b-b94c-40f3-a344-ac767b78bef5)

