### PR TITLE
Speedup of EventList initialization

### DIFF
--- a/src/gdt/core/data_primitives.py
+++ b/src/gdt/core/data_primitives.py
@@ -501,10 +501,10 @@ class EventList():
             times = np.array([], dtype=float)
             channels = np.array([], dtype=int)
         
-        events = zip(*(times, channels))
-        self._events = np.array(list(events), 
-                                dtype=[('TIME', times.dtype.type),
-                                       ('PHA', channels.dtype.type)])
+        self._events = np.empty(times.size, dtype=[('TIME', times.dtype.type),
+                                                   ('PHA', channels.dtype.type)])
+        self._events['TIME'] = times
+        self._events['PHA'] = channels
         
         if ebounds is not None:
             if not isinstance(ebounds, Ebounds):


### PR DESCRIPTION
The current main branch uses a list conversion when initializing the `_events` array of the `EventList` class from data_primitives.py

https://github.com/USRA-STI/gdt-core/blob/cef6fd55c0804d09df8e28f1274ee9dbb92b9098/src/gdt/core/data_primitives.py#L505

This conversion incurs a large performance penalty as noted in issue #43. This pull request removes the performance penalty by creating an empty numpy array and then copying the times and channels arrays.  Merging this request closes issue #43.