### PR TITLE
Remove Need to Run "gdt-data init" manually

### DIFF
--- a/src/gdt/core/__init__.py
+++ b/src/gdt/core/__init__.py
@@ -37,7 +37,7 @@ if sys.version_info < (3, 10):
 else:
     from importlib.resources import files
 
-gdt_data = files('gdt.data')
+_gdt_data = files('gdt.data')
 
 __version__ = '2.0.4'
 
@@ -57,8 +57,8 @@ else:
 
 # Create the data directory and copy a sample spectral data file for tutorial
 data_path.mkdir(parents=True, exist_ok=True)
-src = gdt_data / 'specfit.npz'
-dest = data_path / 'specfit.npz'
+_src = _gdt_data / 'specfit.npz'
+_dest = data_path / 'specfit.npz'
 
-if not dest.exists():
-    shutil.copyfile(src, dest)
+if not _dest.exists():
+    shutil.copyfile(_src, _dest)

--- a/src/gdt/core/__init__.py
+++ b/src/gdt/core/__init__.py
@@ -28,6 +28,16 @@
 #
 import os
 from pathlib import Path
+import shutil
+
+# Use the backport version if importlib.resources for Python earlier than 3.10
+import sys
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
+gdt_data = files('gdt.data')
 
 __version__ = '2.0.4'
 
@@ -44,3 +54,11 @@ if 'GDT_DATA' in os.environ:
     data_path = Path(os.environ['GDT_DATA'])
 else:
     data_path = base_path.joinpath('test_data')
+
+# Create the data directory and copy a sample spectral data file for tutorial
+data_path.mkdir(parents=True, exist_ok=True)
+src = gdt_data / 'specfit.npz'
+dest = data_path / 'specfit.npz'
+
+if not dest.exists():
+    shutil.copyfile(src, dest)


### PR DESCRIPTION
running gdt-data init when a user wants to include this as a part of a required package, ie it is specified in their requirements.txt, that they may be developing is not ideal. If a user installs one package then they will need to manually run this "gdt-data init" which is not very intuitive.

This change allows the required directory to be created (if needed) when the gdt package is imported the first time and moves the necessary test file into the directory. In subsequent imports of gdt.core, the directory will already exist and be setup preventing a user having to take the additional step of ensuring that this package is property initialized. 