### PR TITLE
Bug fix in HealPixLocalization.from_annulus

### DIFF
--- a/src/gdt/core/healpix.py
+++ b/src/gdt/core/healpix.py
@@ -717,7 +717,7 @@ class HealPixLocalization(HealPix):
             # approximate arclength determines number of points in each annulus
             arclength = 2.0*np.pi*x[i]
             numpts = int(np.ceil(arclength/res))*10
-            circ = sky_circle(x[i], center_phi, center_theta, num_points=numpts)
+            circ = sky_circle(center_phi, center_theta, x[i], num_points=numpts)
             theta = np.pi / 2.0 - circ[1]
             phi = circ[0]
             


### PR DESCRIPTION
There was a bug in the class method that creates a HealPixLocalization object from a specified annulus that is parametrized by its center, angular radius, and width.  In calling the [circle function](https://github.com/USRA-STI/gdt-core/blob/4392236a136f5a3fe9a75784a9e998be5e6cfc4e/src/gdt/core/plot/lib.py#L415), the arguments were in the wrong order.  Specifically, (`radius`, `center_x`, and `center_y`) were passed instead of the required order of (`center_x`, and `center_y`, `radius`).  This resulted in the following problem:

```python
# create an annulus at RA=180, Dec=30, radius=20 deg, width=3 deg
hpx = HealPixLocalization.from_annulus(180.0, 30.0, 20.0, 3.0)
eqplot = EquatorialPlot()
eqplot.add_localization(hpx, earth=False, sun=False, detectors=[], galactic_plane=False)
``` 
![problem](https://github.com/user-attachments/assets/f3012c56-73ff-469b-9845-f6d8f1f89722)

After implementing the fix, the same annulus plots  correctly:
![fixed](https://github.com/user-attachments/assets/c4efc2a1-ab79-4d36-a082-f7c5a3c963ce)

