### PR TITLE
API and fits header fixes

### DIFF
--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -81,7 +81,7 @@ class Header(fits.Header):
     def __setitem__(self, key, val):
         
         # pass-through for COMMENT
-        if isinstance(key, tuple):
+        if isinstance(val, tuple):
             super().__setitem__(key, val)
             return
         

--- a/src/gdt/core/headers.py
+++ b/src/gdt/core/headers.py
@@ -79,9 +79,9 @@ class Header(fits.Header):
             self['EXTNAME'] = self.name
 
     def __setitem__(self, key, val):
-        
+
         # pass-through for COMMENT
-        if isinstance(val, tuple):
+        if isinstance(key, tuple) or isinstance(val, tuple):
             super().__setitem__(key, val)
             return
         

--- a/src/gdt/core/pha.py
+++ b/src/gdt/core/pha.py
@@ -515,9 +515,10 @@ class Pha(FitsFileContextManager):
                                             header=self.headers['GTI'])
         
         for key, val in self.headers['GTI'].items():
-            hdu.header[key] = val        
-        hdu.header.comments['TZERO1'] = 'Offset, equal to TRIGTIME'
-        hdu.header.comments['TZERO2'] = 'Offset, equal to TRIGTIME'
+            hdu.header[key] = val
+        if self.trigtime is not None:
+            hdu.header.comments['TZERO1'] = 'Offset, equal to TRIGTIME'
+            hdu.header.comments['TZERO2'] = 'Offset, equal to TRIGTIME'
         return hdu
 
     def __repr__(self):

--- a/src/gdt/core/plot/drm.py
+++ b/src/gdt/core/plot/drm.py
@@ -110,7 +110,7 @@ class ResponsePlot(GdtPlot):
 
         # update the background color of the colorbar
         if self._colorbar:
-            self._drm._artists[-1].patch.set_facecolor(self._background)
+            self._drm._artists[-1].ax.set_facecolor(self._background)
     
     def _init_multiplot(self):
         # initialize the multiplot

--- a/src/gdt/core/plot/model.py
+++ b/src/gdt/core/plot/model.py
@@ -57,7 +57,7 @@ class ModelFit(GdtPlot):
     def __init__(self, fitter=None, canvas=None, view='counts', resid=True,
                  interactive=True):
         
-        warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+        warnings.filterwarnings("ignore", category=np.exceptions.VisibleDeprecationWarning)
         
         self._figure, axes = plt.subplots(2, 1, sharex=True, sharey=False, 
                                           figsize=(5.7, 6.7), dpi=100, 

--- a/src/gdt/core/plot/plot.py
+++ b/src/gdt/core/plot/plot.py
@@ -833,7 +833,7 @@ class Heatmap(PlotElement):
                           format=ticker.FuncFormatter(sci_fmt))
         cb.ax.tick_params(labelsize=10)
         cb.set_label(r'Effective Area (cm$^2$)', fontsize=12)
-        cb.draw_all()
+        cb._draw_all()
         return cb
 
     def __repr__(self):
@@ -2108,4 +2108,3 @@ class PlotElementCollection(DataCollection):
     """
     def __getattr__(self, name):
         return self.get_item(name)
-    

--- a/tests/core/background/test_fitter.py
+++ b/tests/core/background/test_fitter.py
@@ -33,7 +33,7 @@ from gdt.core.background.fitter import BackgroundFitter
 from gdt.core.background.binned import Polynomial
 from gdt.core.background.unbinned import NaivePoisson
 
-
+this_dir = os.path.dirname(__file__)
 
 class TestBinnedFitter(unittest.TestCase):
 
@@ -85,7 +85,19 @@ class TestBinnedFitter(unittest.TestCase):
         rates = self.fitter.interpolate_bins(self.phaii.data.tstart, 
                                              self.phaii.data.tstop)
         self.assertTupleEqual(rates.size, (6, 8))
-     
+
+    def test_write(self):
+
+        filepath = os.path.join(this_dir, 'test.bak')
+
+        rates = self.fitter.interpolate_bins(self.phaii.data.tstart,
+                                             self.phaii.data.tstop)
+        bak = rates.to_bak(time_range=(0, 1))
+        bak.write(directory=this_dir, filename=os.path.basename(filepath), overwrite=True)
+
+        self.assertTrue(os.path.exists(filepath))
+        os.remove(filepath)
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             BackgroundFitter.from_phaii(0.0, Polynomial)
@@ -184,5 +196,4 @@ class TestUnbinnedFitter(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
       
-        
         


### PR DESCRIPTION
This pull request contains the following bug fixes:

1. Minor updates to handle current matplotlib / numpy API. This addresses #68 
2. More robust handling of fits headers. This addresses #70

The changes involve:
* switching from `colorbar.draw_all()` to `colorbar._draw_all()` because `draw_all()` was removed in Matplotlib 3.8.0
* switching from `colorbar.patch.set_facecolor()` to `colorbar.ax.set_facecolor()` because `colorbar.patch` was removed in Matplotlib 3.7.0
* switching from `np.VisibleDeprecationWarning` to `np.exceptions.VisibleDeprecationWarning` because exceptions are not exposed in the main namespace as-of numpy 2.0.0
* checking if trigtime is None before updating TZERO1/2 descriptors because these fields are only present when we have a trigtime.
* checking if the header value is passed as a tuple. A tuple is used when updating the field descriptor via a statement like `header.comments['field'] = 'updated description'`

I also added a unit test for writing a bak file from the background fitter. In this test we write a file with trigtime == None, which is the scenario that triggered the issues seen in #70 

Testing on my computer showed a failed unit test for tests/core/spectra/test_fitting.py, but it appears unrelated to the changes here. All other unit tests complete successfully. The reported unit test error is: 
```
self = <tests.core.spectra.test_fitting.TestCOBYLA testMethod=test_parameters>

    def test_parameters(self):
>       self.assertAlmostEqual(self.fitter.parameters[0], 0.05, places=2)
E       AssertionError: np.float64(0.0001000001) != 0.05 within 2 places (np.float64(0.049899999900000006) difference)

tests/core/spectra/test_fitting.py:739: AssertionError
```