### PR TITLE
Fixed numeric formatting within FITS header card image.

### DIFF
--- a/tests/core/test_fits.py
+++ b/tests/core/test_fits.py
@@ -28,21 +28,21 @@
 #
 import unittest
 
-from gdt.core.fits import exponential_card, fixed_card
+from gdt.core.fits import scientific_card, fixed_card
 
 class TestFitCards(unittest.TestCase):
     def test_fixed_card(self):
         val = 7.428703703703703e-4
         card = fixed_card('FIXEDV', val, comment='fixed floating point')
-        assert card.image == "FIXEDV  = 0.00074              / fixed floating point                           "
+        assert card.image == "FIXEDV  =              0.00074 / fixed floating point                           "
 
-    def test_exponential_card_float(self):
+    def test_scientific_card(self):
         val = 7.428703703703703e-4
-        card = exponential_card('FLOATV', val, comment='exponential floating point')
-        assert card.image == "FLOATV  = 7.42870E-4           / exponential floating point                     "
+        card = scientific_card('FLOATV', val, comment='exponential floating point')
+        assert card.image == "FLOATV  =           7.42870E-4 / exponential floating point                     "
 
-    def test_exponential_card_double(self):
+    def test_scientific_card_use_d(self):
         val = 7.428703703703703e-4
-        card = exponential_card('DOUBLV', val, places=15, use_double=True,
+        card = scientific_card('DOUBLV', val, places=15, use_d=True,
                                 comment='exponential floating point (as double)')
         assert card.image == "DOUBLV  = 7.428703703703703D-4 / exponential floating point (as double)         "


### PR DESCRIPTION
While working on a unified solution for header creation based on headers being a list of tuples and creators such as:

```python
>>> from gdt.cord.fits import fixed_card, scientific_card
>>> from astropy.io.fits import Header

>>> cards = [
    ('CARD1', 'sample', 'this is a comment'),
    ('CARD2', 12, 'ordinary integer value'),
    ('CARD3', 12.5, 'ordinary floating point value'),
    fixed_card('CARD4', 12.125, places=4, comment='fixed-format floating point'),
    scientific_card('CARD5', 0.012345, places=4, comment='floating point in scientific notation'),
    scientific_card('CARD6',0.00002468, places=4, comment='floating point in "D" scientific notation', use_d=True),
]

>>> headers = fits.Header(cards)
>>> headers
CARD1   = 'sample  '           / this is a comment                              
CARD2   =                   12 / ordinary integer value                         
CARD3   =                 12.5 / ordinary floating point value                  
CARD4   =              12.1250 / fixed-format floating point                    
CARD5   =            1.2345E-2 / floating point in scientific notation          
CARD6   =            2.4680D-5 / floating point in "D" scientific notation
```

I checked the FITS standard and realized that numeric values should be RIGHT justified and made the correction in _create_card(...).

In addition, I eliminated type conversions by calculating the mantissa and exponent instead of parsing a formatted string.

for a given value:
    exponent = int(ceil(log10(value))
    mantissa = float( value / pow(10, exponent) )
