### PR TITLE
Fix for contour plotting artifacts 

### DIFF
--- a/src/gdt/core/healpix.py
+++ b/src/gdt/core/healpix.py
@@ -472,11 +472,8 @@ class HealPixLocalization(HealPix):
         # use matplotlib contour to produce a path object
         contour = Contour(ra, dec, sig_arr, [clevel])
 
-        # get the contour path, which is made up of segments
-        paths = contour.collections[0].get_paths()
-
         # extract all the vertices
-        pts = [path.vertices for path in paths]
+        pts = contour.allsegs[0]
 
         # unfortunately matplotlib will plot this, so we need to remove
         for c in contour.collections:


### PR DESCRIPTION
This pull request contains a fix to reduce contour plotting artifacts from `confidence_region_path()` in current versions of matplotlib.

**Reason for the change:**
In old matplotlib versions like 3.2.2 the `collections[0].get_path()` method returned multiple, separate paths in cases where the contour was fragmented into multiple polygons. However, current matplotlib versions return a single set of points for all fragments, which results in spurious lines/polygons that cross between the fragments. We should instead use `contour.allsegs[0]` to retrieve a list of vertices separated according to the separate contour segments. 

An example of this is shown below in plots for a fixed resolution skymap of GW test event MS230303q. In this case the existing main branch draws an extra line between the two separate portions of the contour. The same plot generated from this PR removes the line, correctly plotting the fragments as separate polygons.

![MS230303q_main](https://github.com/user-attachments/assets/0db5e356-4c0e-488b-9aca-fdbd8c3245c8)
![MS230303q_updated](https://github.com/user-attachments/assets/112de222-02da-4024-a6d1-7418c24d7352)
