### PR TITLE
Fixes for creating and plotting effective area on the sky

### DIFF
--- a/src/gdt/core/healpix.py
+++ b/src/gdt/core/healpix.py
@@ -317,7 +317,8 @@ class HealPixEffectiveArea(HealPix):
         
         angles = coord.separation(coords)
         eff_area = eff_area_normal * np.cos(coeff * angles.to('rad')).value
-        mask = coeff * angles.value > 90.0
+        eff_area[(eff_area < 0.0)] = 0.0
+        mask = angles.value > 90.0 / coeff
         eff_area[mask] = 0.0
         return cls.from_data(eff_area, filename=filename, **kwargs)
 

--- a/src/gdt/core/plot/lib.py
+++ b/src/gdt/core/plot/lib.py
@@ -935,18 +935,13 @@ def sky_heatmap(x, y, heatmap, ax, cmap='RdPu', norm=None, flipped=True,
     if frame == 'spacecraft':
         flipped = False
         
-        # plots from azimuth (0, +180)
+        # plots from azimuth (0->180)
         phi1 = phi + np.pi
-        phi1_mask = phi1 > np.pi
-        phi1[phi1_mask] = 2.0*np.pi - phi1[phi1_mask]
         image1 = ax.pcolormesh(phi1, theta, heatmap, rasterized=True, cmap=cmap,
                                norm=norm)
         
-        # plots from azimuth (-180, 0)
+        # plots from azimuth (180->0)
         phi2 = phi - np.pi
-        phi2_mask = phi2 < -np.pi
-        phi2[phi2_mask] = 2.0*np.pi + phi2[phi2_mask]
-
         image2 = ax.pcolormesh(phi2, theta, heatmap, rasterized=True, cmap=cmap,
                                norm=norm)
         return [image1, image2]


### PR DESCRIPTION
The plotting of effective area (a gradient heatmap) in the spacecraft frame was incorrect whenever the effective area overlapped the azimuth=0 meridian, resulting in plotting artifacts.  These artifacts were exacerbated whenever the heatmap extended to either of the poles. As an example: 

```python
import matplotlib.pyplot as plt
from gdt.core.healpix import *
from gdt.core.plot.sky import *

hpx = HealPixEffectiveArea.from_cosine(30.0, 30.0, 100.0, coeff=1.0)
scplot = SpacecraftPlot()
scplot.add_effective_area(hpx)
plt.show()
```
![incorrect](https://github.com/user-attachments/assets/8ba9e032-355e-4775-9f77-c4a96061025d)

This PR implements a fix (and simplification) that correctly plots the effective area, as shown below:

![fixed](https://github.com/user-attachments/assets/6c8ef810-f7d8-49be-9544-ba4d1103672a)

Additionally, a fix was implemented to mask out negative effective area values and set them to zero when the `HealPixEffectiveArea.from_cosine()` function is called.