### PR TITLE
Fixing `Pha.energy_range` when creating from `Phaii.to_pha()`

### DIFF
--- a/src/gdt/core/pha.py
+++ b/src/gdt/core/pha.py
@@ -156,7 +156,9 @@ class Pha(FitsFileContextManager):
     def energy_range(self):
         """(float, float): The energy range of the spectrum"""
         if self._data is not None:
-            return self._data.range
+            lo = self._data.lo_edges[self._channel_mask][0]
+            hi = self._data.hi_edges[self._channel_mask][-1]
+            return (lo, hi)
 
     @property
     def exposure(self):

--- a/tests/core/test_phaii.py
+++ b/tests/core/test_phaii.py
@@ -217,6 +217,7 @@ class TestPhaii(unittest.TestCase):
         self.assertAlmostEqual(pha.exposure, 0.3188)
         self.assertTupleEqual(pha.time_range, (0.0, 0.320))
         self.assertEqual(pha.num_chans, 8)
+        self.assertEqual(pha.energy_range, (49.60019, 538.1436))
         self.assertListEqual(pha.valid_channels.tolist(), [3, 4, 5])
 
         # subset of the channel range
@@ -224,6 +225,7 @@ class TestPhaii(unittest.TestCase):
         self.assertAlmostEqual(pha.exposure, 0.3188)
         self.assertTupleEqual(pha.time_range, (0.0, 0.320))
         self.assertEqual(pha.num_chans, 8)
+        self.assertEqual(pha.energy_range, (49.60019, 538.1436))
         self.assertListEqual(pha.valid_channels.tolist(), [3, 4, 5])
 
     def test_write(self):        


### PR DESCRIPTION
This fixes issue USRA-STI/gdt-fermi#46.

When a `Pha` object is created from a `Phaii` object, the requirement in the OGIP standard is to maintain all energy channels, even if those energy channels are sliced or masked out.  This is why there is a `Pha.channel_mask` attribute: to mark which channels have been removed by a channel slice operation.  The `Pha.energy_range` simply wrapped the underlying `EnergyBins.range` attribute, but this is misleading, at best, when some of channels are masked out. This PR fixes this issue by applying the channel mask to the energy channels in the underlying `EnergyBins` object to generate the updated energy range.

```python
from gdt.missions.fermi.gbm.tte import GbmTte
from gdt.core.binning.unbinned import bin_by_time

# Open TTE file
tte = GbmTte.open('glg_tte_n6_bn150506630_v00.fit')

# Bin the data by time
phaii = tte.to_phaii(bin_by_time, 1.024, time_ref=0.0)

# Convert to PHA file (set energy range)
pha2 = phaii.to_pha(time_ranges=(0., 0.512), energy_range=(8.,900.))
```

Before fix:
```python
print (pha2.energy_range)
(5.307523250579834, 2000.0)
```

After fix:
```python
print (pha2.energy_range)
(7.165655136108398, 908.2603759765625)
```