### PR TITLE
Improving the creation of `Pha` objects with a `valid_channels`

### DIFF
--- a/src/gdt/core/data_primitives.py
+++ b/src/gdt/core/data_primitives.py
@@ -273,6 +273,23 @@ class Intervals():
         edges = [interval._high for interval in self._intervals]
         return edges
 
+    def index(self, value):
+        """Return the index of the interval that contains the value.
+        
+        Note :
+            If the value is precisely on the boundary of two intervals, the
+            first interval index will be returned.
+        
+        Args:
+            value (float): The input value
+        
+        Returns:
+            (int)
+        """
+        for i, interval in enumerate(self._intervals):
+            if interval.contains(value, inclusive=True):
+                return i        
+    
     def insert(self, interval):
         """Insert a new interval
         

--- a/src/gdt/core/pha.py
+++ b/src/gdt/core/pha.py
@@ -319,21 +319,24 @@ class Pha(FitsFileContextManager):
             # if no channel mask is given, check to see if there is a list of
             # valid channels
             if valid_channels is not None:
+                if not isinstance(valid_channels, (np.ndarray, list, tuple, set)):
+                    raise TypeError('valid_channels must be an iterable')
                 try:
-                    iter(valid_channels)
                     valid_channels = np.asarray(valid_channels).flatten().astype(int)
-                    channel_mask[valid_channels] = True
-                except:
-                    raise TypeError('valid_channels must be an integer array')
+                except ValueError:
+                    raise ValueError('valid_channels must contain integer values')
+                channel_mask[valid_channels] = True
             
             else: # otherwise assume zero-count channels are bad
                 channel_mask[data.counts > 0] = True
             
+        if not isinstance(channel_mask, (np.ndarray, list, tuple, set)):
+            raise TypeError('channel_mask must be an iterable')
         try:
-            iter(channel_mask)
-            channel_mask = np.asarray(channel_mask).flatten().astype(bool)
-        except:
-            raise TypeError('channel_mask must be a Boolean array')
+            channel_mask = np.asarray(channel_mask).flatten().astype(bool)        
+        except ValueError: 
+            raise ValueError('channel_mask must contain booleans')
+        
         if channel_mask.size != obj._data.size:
             raise ValueError('channel_mask must be the same size as the ' \
                              'number of data bins')

--- a/src/gdt/core/simulate/pha.py
+++ b/src/gdt/core/simulate/pha.py
@@ -198,7 +198,7 @@ class PhaSimulator:
             tstart (float, optional): The start time. If not set, then is zero.
             tstop (float, optional): Then end time. If not set, then is the 
                                      exposure.
-            **kwargs: Options passed to :class:`~gdt.core.pha.Pha`
+            **kwargs: Options passed to :meth:`~gdt.core.pha.Pha.from_data`
         
         Returns:
             (list of :class:`~gdt.core.pha.Pha`)

--- a/tests/core/test_pha.py
+++ b/tests/core/test_pha.py
@@ -244,6 +244,17 @@ class TestPhaChannelMask(unittest.TestCase):
     def test_valid_channels(self):
         assert self.pha.valid_channels.tolist() == [1, 2, 3, 4, 5]
 
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            Pha.from_data(self.pha.data, self.pha.gti, channel_mask=True)
+        
+        with self.assertRaises(ValueError):
+            Pha.from_data(self.pha.data, self.pha.gti, channel_mask=('test',))
+
+        with self.assertRaises(ValueError):
+            Pha.from_data(self.pha.data, self.pha.gti, channel_mask=[True, False])
+            
+
 
 class TestPhaValidChannels(unittest.TestCase):
     
@@ -272,6 +283,13 @@ class TestPhaValidChannels(unittest.TestCase):
     def test_valid_channels(self):
         assert self.pha.valid_channels.tolist() == [1, 2, 4, 5]
 
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            Pha.from_data(self.pha.data, self.pha.gti, valid_channels=0)
+        
+        with self.assertRaises(ValueError):
+            Pha.from_data(self.pha.data, self.pha.gti, valid_channels=('test',))
+            
 
 class TestPhaZeroCounts(unittest.TestCase):
     

--- a/tests/core/test_pha.py
+++ b/tests/core/test_pha.py
@@ -216,6 +216,89 @@ class TestPha(unittest.TestCase):
             pha = Pha.from_data(self.pha.data)
             pha.write(this_dir)
 
+
+class TestPhaChannelMask(unittest.TestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        counts = [119, 71, 34, 30, 21, 6, 2, 19]
+        emin = [4.323754, 11.464164, 26.22962, 49.60019, 101.016815,
+                290.46063, 538.1436, 997.2431]
+        emax = [11.464164, 26.22962, 49.60019, 101.016815, 290.46063,
+                538.1436, 997.2431, 2000.]
+        exposure = 0.25459924
+         
+        data = EnergyBins(counts, emin, emax, exposure)
+        gti = Gti.from_list([(-899.0864419937134, -898.8306360244751)])
+        channel_mask = [False, True, True, True, True, True, False, False]
+        cls.pha = Pha.from_data(data, gti=gti, trigger_time=356223561.133346,
+                                channel_mask=channel_mask)
+
+    def test_channel_mask(self):
+        assert self.pha.channel_mask.tolist() == [False, True, True, True, 
+                                                  True, True, False, False]
+    
+    def test_energy_range(self):
+        assert self.pha.energy_range == (11.464164, 538.1436)
+
+    def test_valid_channels(self):
+        assert self.pha.valid_channels.tolist() == [1, 2, 3, 4, 5]
+
+
+class TestPhaValidChannels(unittest.TestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        counts = [119, 71, 34, 30, 21, 6, 2, 19]
+        emin = [4.323754, 11.464164, 26.22962, 49.60019, 101.016815,
+                290.46063, 538.1436, 997.2431]
+        emax = [11.464164, 26.22962, 49.60019, 101.016815, 290.46063,
+                538.1436, 997.2431, 2000.]
+        exposure = 0.25459924
+         
+        data = EnergyBins(counts, emin, emax, exposure)
+        gti = Gti.from_list([(-899.0864419937134, -898.8306360244751)])
+        valid_channels = [1, 2, 4, 5]
+        cls.pha = Pha.from_data(data, gti=gti, trigger_time=356223561.133346,
+                                valid_channels=valid_channels)
+
+    def test_channel_mask(self):
+        assert self.pha.channel_mask.tolist() == [False, True, True, False, 
+                                                  True, True, False, False]
+    
+    def test_energy_range(self):
+        assert self.pha.energy_range == (11.464164, 538.1436)
+
+    def test_valid_channels(self):
+        assert self.pha.valid_channels.tolist() == [1, 2, 4, 5]
+
+
+class TestPhaZeroCounts(unittest.TestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        counts = [0, 71, 0, 30, 0, 6, 0, 0]
+        emin = [4.323754, 11.464164, 26.22962, 49.60019, 101.016815,
+                290.46063, 538.1436, 997.2431]
+        emax = [11.464164, 26.22962, 49.60019, 101.016815, 290.46063,
+                538.1436, 997.2431, 2000.]
+        exposure = 0.25459924
+         
+        data = EnergyBins(counts, emin, emax, exposure)
+        gti = Gti.from_list([(-899.0864419937134, -898.8306360244751)])
+        cls.pha = Pha.from_data(data, gti=gti, trigger_time=356223561.133346)
+
+    def test_channel_mask(self):
+        assert self.pha.channel_mask.tolist() == [False, True, False, True, 
+                                                  False, True, False, False]
+    
+    def test_energy_range(self):
+        assert self.pha.energy_range == (11.464164, 538.1436)
+
+    def test_valid_channels(self):
+        assert self.pha.valid_channels.tolist() == [1, 3, 5]
+
+
 class TestBak(unittest.TestCase):
     
     @classmethod

--- a/tests/core/test_primitives.py
+++ b/tests/core/test_primitives.py
@@ -197,6 +197,12 @@ class TestIntervals(unittest.TestCase):
     def test_high_edges(self):
         self.assertListEqual(self.intervals.high_edges(), [10.0, 20.0, 30.0])
 
+    def test_index(self):
+        assert self.intervals.index(5.0) == 0
+        assert self.intervals.index(20.0) == 1
+        assert self.intervals.index(-5.0) is None
+        assert self.intervals.index(50.0) is None
+
     def test_insert(self):
     
         # insert a duplicate


### PR DESCRIPTION
This PR resolves both issues #50 and #66. 

The creation of a `Pha` object using the `from_data()` method can now accept a `valid_channels` keyword that contains the list of valid channel numbers.  Prior to this update, only a `channel_mask` array of boolean values for each channel could be used.  

For example:
```python
import numpy as np
from gdt.core.pha import Pha

# set the valid channel numbers to be used for e.g. spectral fitting
valid_channels = np.array([4, 5, 6, 7, 22, 23, 24])
pha = Pha.from_data(data, valid_channels=valid_channels)
```

Additionally, a new method, `index()` has been added to the `Intervals` class that allows us to return the index of the interval list that contains a input value, which is also inherited by the `Gti` and `Ebounds` classes.  This method is useful for converting from physical units to index/channel units, for example converting from energy to energy channel:

```python
from gdt.core.data_primitives import Ebounds

emin = [4.0, 11.0, 26.0, 50.0, 101.0, 290.0, 538.0, 997.0]
emax = [11.0, 26.0, 50.0, 101.0, 290.0, 538.0, 997.0, 2000.0]
ebounds = Ebounds.from_bounds(emin, emax)

# channel of EBOUNDS that contains 300 keV
print(ebounds.index(300.0))
5
```