### PR TITLE
Fix for updated Matplotlib API

### DIFF
--- a/src/gdt/core/healpix.py
+++ b/src/gdt/core/healpix.py
@@ -67,29 +67,29 @@ class HealPix():
 
     def convolve(self, model, *args, **kwargs):
         """Convolve the map with a model kernel.  The model can be a Gaussian
-        kernel or any mixture of Gaussian kernels. Uses `healpy.smoothing 
+        kernel or any mixture of Gaussian kernels. Uses `healpy.smoothing
         <https://healpy.readthedocs.io/en/latest/generated/healpy.sphtfunc.smoothing.html>`_.
-        
+
         An example of a model kernel with a 50%/50% mixture of two Gaussians,
         one with a 1-deg width, and the other with a 3-deg width::
-            
+
             def gauss_mix_example():
                 sigma1 = np.deg2rad(1.0)
                 sigma2 = np.deg2rad(3.0)
                 frac1 = 0.50
                 return ([sigma1, sigma2], [frac1])
-        
-        Args: 
+
+        Args:
             model (<function>): The function representing the model kernel
             *args: Arguments to be passed to the model kernel function
-        
+
         Returns:
             (:class:`HealPix`)
         """
         # evaluate model
         sigmas, fracs = model(*args)
 
-        # determine number of gaussians, and ensure that they match the 
+        # determine number of gaussians, and ensure that they match the
         # number of fractional weights
         num_sigmas = len(sigmas)
         if len(fracs) != num_sigmas:
@@ -102,19 +102,19 @@ class HealPix():
         new_hpx = np.zeros(self._hpx.shape)
         for i in range(num_sigmas):
             new_hpx += fracs[i] * hp.smoothing(self._hpx, sigma=sigmas[i])
-                
+
         return type(self).from_data(new_hpx, trigtime=self.trigtime, **kwargs)
 
     @classmethod
     def from_data(cls, hpx_arr, trigtime=None, filename=None, **kwargs):
         """Create a HealPix object from healpix arrays
-        
+
         Args:
             hpx_arr (np.array): The HEALPix array
             trigtime (float, optional): The reference time for the map
             filename (str, optional): The filename
-        
-        Returns:        
+
+        Returns:
             (:class:`HealPix`)
         """
         obj = cls()
@@ -124,7 +124,7 @@ class HealPix():
         except:
             raise TypeError('hpx_arr must be an array')
         obj._hpx = hpx_arr
-        
+
         if trigtime is not None:
             try:
                 trigtime = float(trigtime)
@@ -133,23 +133,23 @@ class HealPix():
             if trigtime < 0.0:
                 raise ValueError('trigtime must be non-negative')
         obj._trigtime = trigtime
-                
+
         obj._filename = filename
-        
+
         return obj
 
     @classmethod
-    def multiply(cls, healpix1, healpix2, primary=0, output_nside=128, 
+    def multiply(cls, healpix1, healpix2, primary=0, output_nside=128,
                  **kwargs):
         """Multiply two HealPix maps and return a new HealPix object
-        
+
         Args:
             healpix1 (:class:`HealPix`): One of the HEALPix maps to multiply
             healpix2 (:class:`HealPix`): The other HEALPix map to multiply
-            primary (int, optional): If 0, use the first map metadata, 
-                                     or if 1, use the second map metadata. 
+            primary (int, optional): If 0, use the first map metadata,
+                                     or if 1, use the second map metadata.
                                      Default is 0.
-            output_nside (int, optional): The nside of the multiplied map. 
+            output_nside (int, optional): The nside of the multiplied map.
                                           Default is 128.
         Returns
             (:class:`HealPix`)
@@ -157,10 +157,10 @@ class HealPix():
         if not isinstance(healpix1, HealPix) or \
            not isinstance(healpix2, HealPix):
             raise TypeError('healpix1 and healpix2 must be HealPix objects')
-        
+
         if primary != 0 and primary != 1:
             raise ValueError('primary must be either 0 or 1')
-        
+
         # if different resolutions, upgrade the lower res, then multiply
         if healpix1.nside > healpix2.nside:
             hpx = healpix1._hpx * hp.ud_grade(healpix2._hpx,
@@ -179,7 +179,7 @@ class HealPix():
             trigtime = healpix1.trigtime
         else:
             trigtime = healpix2.trigtime
-        
+
         return cls.from_data(hpx, trigtime=trigtime, **kwargs)
 
     @staticmethod
@@ -213,7 +213,7 @@ class HealPix():
             raise TypeError('num_phi and num_theta must be positive integers')
         if num_phi <= 0 or num_theta <= 0:
             raise ValueError('num_phi and num_theta must be positive')
-        
+
         # create the mesh grid in phi and theta
         theta = np.linspace(np.pi, 0.0, num_theta)
         phi = np.linspace(0.0, 2 * np.pi, num_phi)
@@ -227,7 +227,7 @@ class HealPix():
 
 
 class HealPixEffectiveArea(HealPix):
-    """Class for effective area HEALPix files 
+    """Class for effective area HEALPix files
     """
     pass
 
@@ -235,50 +235,50 @@ class HealPixEffectiveArea(HealPix):
     def eff_area(self):
         """(np.array): The effective area HEALPix array"""
         return self._hpx
-    
+
     def effective_area(self, az, zen):
         """Calculate the effective area at a given point.  This
         function interpolates the map at the requested point rather than
         providing the vale at the nearest pixel center.
-        
+
         Args:
             az (float): The Azimuth
             zen (float): The Zenith
-        
+
         Returns:
             (float)
         """
         phi = self._ra_to_phi(az)
         theta = np.deg2rad(zen)
         eff_area = hp.get_interp_val(self.eff_area, theta, phi)
-        return eff_area  
-    
+        return eff_area
+
     def make_grid(self, numpts_az=360, numpts_zen=180):
         """Return the effective area mapped to a grid.
-        
+
         Args:
-            numpts_az (int, optional): The number of grid points along the Az 
+            numpts_az (int, optional): The number of grid points along the Az
                                        axis. Default is 360.
-            numpts_zen (int, optional): The number of grid points along the Zen 
+            numpts_zen (int, optional): The number of grid points along the Zen
                                         axis. Default is 180.
 
-        Returns: 
+        Returns:
             3-tuple containing:
-            
+
             - *np.array*: The effective area array with shape
                       (``numpts_zen``, ``numpts_az``)
             - *np.array*: The Az grid points
             - *np.array*: The Zen grid points
-        """        
+        """
         grid_pix, phi, theta = self._mesh_grid(numpts_az, numpts_zen)
         return (self.eff_area[grid_pix], self._phi_to_ra(phi), np.rad2deg(theta))
-    
+
     @classmethod
-    def from_cosine(cls, az, zen, eff_area_normal, coeff=1.0, nside=64, 
+    def from_cosine(cls, az, zen, eff_area_normal, coeff=1.0, nside=64,
                     filename=None, **kwargs):
         """Create an object with effective area that has a cosine angular
         depndence.
-        
+
         Args:
             az (float): The azimuth of the detector normal
             zen (float): The zenith of the detector normal
@@ -286,7 +286,7 @@ class HealPixEffectiveArea(HealPix):
             coeff (float, optional): The cosine coefficient to use. Default is 1
             nside (int, optional): The nside of the HEALPix to make. Default is 64
             filename (str, optional): The filename
-        
+
         Returns:
             (:class:`HealPixEffectiveArea`)
         """
@@ -297,7 +297,7 @@ class HealPixEffectiveArea(HealPix):
             coeff = float(coeff)
         except:
             raise TypeError('az, zen, eff_area_normal, and coeff must be floats')
-    
+
         az = az % 360.0
         if zen < 0.0 or zen > 180.0:
             raise ValueError('zen must be between 0 and 180')
@@ -306,15 +306,15 @@ class HealPixEffectiveArea(HealPix):
             raise ValueError('eff_area_normal must be non-negative')
         if coeff <= 0.0:
             raise ValueError('coeff must be positive')
-       
+
         coord = SkyCoord(az, 90-zen, unit='deg')
-        
+
         npix = hp.nside2npix(nside)
         theta, phi = hp.pix2ang(nside, np.arange(npix))
         azs = cls._phi_to_ra(phi)
         zens = np.rad2deg(theta)
         coords = SkyCoord(azs, 90.0-zens, unit='deg')
-        
+
         angles = coord.separation(coords)
         eff_area = eff_area_normal * np.cos(coeff * angles.to('rad')).value
         eff_area[(eff_area < 0.0)] = 0.0
@@ -325,12 +325,12 @@ class HealPixEffectiveArea(HealPix):
     @classmethod
     def from_uniform(cls, eff_area, nside=64, filename=None, **kwargs):
         """Create an object with uniform effective area.
-        
+
         Args:
             eff_area (float): The effective area.
             nside (int, optional): The nside of the HEALPix to make.
             filename (str, optional): The filename
-        
+
         Returns:
             (:class:`HealPixEffectiveArea`)
         """
@@ -340,7 +340,7 @@ class HealPixEffectiveArea(HealPix):
             raise TypeError('eff_area must be a non-negative float')
         if eff_area < 0:
             raise ValueError('eff_area must be non-negative')
-        
+
         npix = hp.nside2npix(nside)
         hpx_arr = np.full(npix, eff_area)
         return cls.from_data(hpx_arr, filename=filename, **kwargs)
@@ -348,16 +348,16 @@ class HealPixEffectiveArea(HealPix):
     @classmethod
     def sum(cls, healpix1, healpix2, primary=0, output_nside=128, **kwargs):
         """Add two HealPixEffectiveArea maps and return a new object
-        
+
         Args:
-            healpix1 (:class:`HealPixEffectiveArea`): One of the HEALPix maps 
+            healpix1 (:class:`HealPixEffectiveArea`): One of the HEALPix maps
                                                       to sum
-            healpix2 (:class:`HealPixEffectiveArea`): The other HEALPix map 
+            healpix2 (:class:`HealPixEffectiveArea`): The other HEALPix map
                                                       to sum
-            primary (int, optional): If 0, use the first map metadata, 
-                                     or if 1, use the second map metadata. 
+            primary (int, optional): If 0, use the first map metadata,
+                                     or if 1, use the second map metadata.
                                      Default is 0.
-            output_nside (int, optional): The nside of the multiplied map. 
+            output_nside (int, optional): The nside of the multiplied map.
                                           Default is 128.
         Returns
             (:class:`HealPixEffectiveArea`)
@@ -366,10 +366,10 @@ class HealPixEffectiveArea(HealPix):
            not isinstance(healpix2, HealPixEffectiveArea):
             raise TypeError('healpix1 and healpix2 must be ' \
                             'HealPixEffectiveArea objects')
-        
+
         if primary != 0 and primary != 1:
             raise ValueError('primary must be either 0 or 1')
-        
+
         # if different resolutions, upgrade the lower res, then multiply
         if healpix1.nside > healpix2.nside:
             hpx = healpix1._hpx + hp.ud_grade(healpix2._hpx,
@@ -388,17 +388,17 @@ class HealPixEffectiveArea(HealPix):
             trigtime = healpix1.trigtime
         else:
             trigtime = healpix2.trigtime
-        
+
         return cls.from_data(hpx, trigtime=trigtime, **kwargs)
 
-        
+
 class HealPixLocalization(HealPix):
-    """Class for localization HEALPix files 
+    """Class for localization HEALPix files
     """
     def __init__(self):
         super().__init__()
         self._sig = None
-    
+
     @property
     def centroid(self):
         """(float, float): The RA, Dec of the centroid"""
@@ -410,18 +410,18 @@ class HealPixLocalization(HealPix):
     def prob(self):
         """(np.array): The HEALPix array for the probability/pixel"""
         return self._hpx
-    
+
     @property
     def sig(self):
         """(np.array): The HEALPix array for the significance of each pixel"""
         return self._sig
-    
+
     def area(self, clevel):
         """Calculate the sky area contained within a given confidence region
-        
+
         Args:
             clevel (float): The localization confidence level (valid range 0-1)
-        
+
         Returns:
             (float)
         """
@@ -431,14 +431,14 @@ class HealPixLocalization(HealPix):
         return numpix * self.pixel_area
 
     def confidence(self, ra, dec):
-        """Calculate the localization confidence level for a given point. 
+        """Calculate the localization confidence level for a given point.
         This function interpolates the map at the requested point rather than
         providing the value at the nearest pixel center.
-        
+
         Args:
             ra (float): The RA
             dec (float): The Dec
-        
+
         Returns:
             (float)
         """
@@ -448,17 +448,17 @@ class HealPixLocalization(HealPix):
 
     def confidence_region_path(self, clevel, numpts_ra=360, numpts_dec=180):
         """Return the bounding path for a given confidence region.
-        
+
         Args:
             clevel (float): The localization confidence level (valid range 0-1)
-            numpts_ra (int, optional): The number of grid points along the RA 
+            numpts_ra (int, optional): The number of grid points along the RA
                                        axis. Default is 360.
-            numpts_dec (int, optional): The number of grid points along the Dec 
+            numpts_dec (int, optional): The number of grid points along the Dec
                                         axis. Default is 180.
-        
+
         Returns:
             ([(np.array, np.array), ...]): A list of RA, Dec points, where each
-                                           item in the list is a continuous 
+                                           item in the list is a continuous
                                            closed path.
         """
         if clevel < 0.0 or clevel > 1.0:
@@ -477,8 +477,7 @@ class HealPixLocalization(HealPix):
         pts = contour.allsegs[0]
 
         # unfortunately matplotlib will plot this, so we need to remove
-        for c in contour.collections:
-            c.remove()
+        contour.remove()
 
         return pts
 
@@ -486,14 +485,14 @@ class HealPixLocalization(HealPix):
         """Calculate the localization probability at a given point.  This
         function interpolates the map at the requested point rather than
         providing the vale at the nearest pixel center.
-        
+
         Args:
             ra (float): The RA
             dec (float): The Dec
-            per_pixel (bool, optional): 
-                If True, return probability per pixel, otherwise return 
+            per_pixel (bool, optional):
+                If True, return probability per pixel, otherwise return
                 probability per square degree. Default is False.
-        
+
         Returns:
             (float)
         """
@@ -507,28 +506,28 @@ class HealPixLocalization(HealPix):
     def prob_array(self, numpts_ra=360, numpts_dec=180, sqdegrees=True,
                    sig=False):
         """Return the localization probability mapped to a grid on the sky
-        
+
         Args:
-            numpts_ra (int, optional): The number of grid points along the RA 
+            numpts_ra (int, optional): The number of grid points along the RA
                                        axis. Default is 360.
-            numpts_dec (int, optional): The number of grid points along the Dec 
+            numpts_dec (int, optional): The number of grid points along the Dec
                                         axis. Default is 180.
-            sqdegrees (bool, optional): 
-                If True, the prob_array is in units of probability per square 
-                degrees, otherwise in units of probability per pixel. 
+            sqdegrees (bool, optional):
+                If True, the prob_array is in units of probability per square
+                degrees, otherwise in units of probability per pixel.
                 Default is True
-            sig (bool, optional): Set True to retun the significance map on a 
-                                  grid instead of the probability. 
+            sig (bool, optional): Set True to retun the significance map on a
+                                  grid instead of the probability.
                                   Default is False.
 
-        Returns: 
+        Returns:
             3-tuple containing:
-            
+
             - *np.array*: The probability (or significance) array with shape \
                       (``numpts_dec``, ``numpts_ra``)
             - *np.array*: The RA grid points
             - *np.array*: The Dec grid points
-        """        
+        """
         grid_pix, phi, theta = self._mesh_grid(numpts_ra, numpts_dec)
 
         if sig:
@@ -542,32 +541,32 @@ class HealPixLocalization(HealPix):
 
     def region_probability(self, healpix, prior=0.5):
         r"""The probability that the HealPix localization is associated with
-        another HealPixLocalization map.  This is calculated against the null 
+        another HealPixLocalization map.  This is calculated against the null
         hypothesis that the two HealPix maps are unassociated:
-        
-        :math:`P(A | \mathcal{I}) = 
+
+        :math:`P(A | \mathcal{I}) =
         \frac{P(\mathcal{I} | A) \ P(A)}
         {P(\mathcal{I} | A) \ P(A) + P(\mathcal{I} | \neg A) \ P(\neg A)}`
-        
+
         where
-        
-        * :math:`P(\mathcal{I} | A)` is the integral over the overlap of the two 
+
+        * :math:`P(\mathcal{I} | A)` is the integral over the overlap of the two
           maps once the Earth occultation has been removed for *this* map.
         * :math:`P(\mathcal{I} | \neg A)` is the integral over the overlap of
-          *this* map with a uniform distribution on the sky (i.e. the probability 
+          *this* map with a uniform distribution on the sky (i.e. the probability
           the localization is associated with a random point on the sky)
-        * :math:`P(A)` is the prior probability that *this* localization is 
+        * :math:`P(A)` is the prior probability that *this* localization is
           associated with the *other* HEALPix map.
-        
+
         Args:
-            healpix (:class:`HealPixLocalization`): The healpix map for which to 
-                                                    calculate the spatial 
+            healpix (:class:`HealPixLocalization`): The healpix map for which to
+                                                    calculate the spatial
                                                     association
             prior (float, optional): The prior probability that the localization
-                                     is associated with the source. 
+                                     is associated with the source.
                                      Default is 0.5
-        
-        Returns:  
+
+        Returns:
             (float)
         """
         if (prior < 0.0) or (prior > 1.0):
@@ -605,29 +604,29 @@ class HealPixLocalization(HealPix):
         a known point location.  This is calculated against the null hypothesis
         that the HealPix localization originates from an unassociated random
         source that has equal probability of origination anywhere in the sky:
-        
-        :math:`P(A | \mathcal{I}) = 
+
+        :math:`P(A | \mathcal{I}) =
         \frac{P(\mathcal{I} | A) \ P(A)}
         {P(\mathcal{I} | A) \ P(A) + P(\mathcal{I} | \neg A) \ P(\neg A)}`
-        
+
         where
-        
+
         * :math:`P(\mathcal{I} | A)` is the probability of the localization at
           the point source once
-        * :math:`P(\mathcal{I} | \neg A)` is the probability per pixel assuming 
-          a uniform distribution on the sky (i.e. the probability the 
+        * :math:`P(\mathcal{I} | \neg A)` is the probability per pixel assuming
+          a uniform distribution on the sky (i.e. the probability the
           localization is associated with a random point on the sky)
-        * :math:`P(A)` is the prior probability that the localization is 
+        * :math:`P(A)` is the prior probability that the localization is
           associated with the point source
-        
+
         Args:
             ra (float): The RA of the known source location
             dec (float): The Dec of the known source location
             prior (float, optional): The prior probability that the localization
-                                     is associated with the source. 
+                                     is associated with the source.
                                      Default is 0.5
-        
-        Returns:        
+
+        Returns:
             (float)
         """
         if (prior < 0.0) or (prior > 1.0):
@@ -648,21 +647,21 @@ class HealPixLocalization(HealPix):
     def from_annulus(cls, center_ra, center_dec, radius, sigma, nside=None,
                      trigtime=None, filename=None, **kwargs):
         """Create a HealPixLocalization object of a Gaussian-width annulus.
-        
+
         Args:
             center_ra (float): The RA of the center of the annulus
             center_dec (float): The Dec of the center of the annulus
-            radius (float): The radius of the annulus, in degrees, measured to 
+            radius (float): The radius of the annulus, in degrees, measured to
                             the center of the of the annulus
-            sigma (float): The Gaussian standard deviation width of the annulus, 
+            sigma (float): The Gaussian standard deviation width of the annulus,
                            in degrees
             nside (int, optional): The nside of the HEALPix to make. By default,
-                                   the nside is automatically determined by the 
-                                   ``sigma`` width.  Set this argument to 
-                                   override the default. 
+                                   the nside is automatically determined by the
+                                   ``sigma`` width.  Set this argument to
+                                   override the default.
             trigtime (float, optional): The reference time for the map
             filename (str, optional): The filename
-                
+
         Return:
             (:class:`HealPixLocalization`)
         """
@@ -681,7 +680,7 @@ class HealPixLocalization(HealPix):
             raise ValueError('radius must be positive')
         if sigma < 0:
             raise ValueError('sigma must be positive')
-        
+
         # Automatically calculate appropriate nside by taking the closest nside
         # with an average resolution that matches 0.2*sigma
         if nside is None:
@@ -689,36 +688,36 @@ class HealPixLocalization(HealPix):
             pix_res = hp.nside2resol(nsides, True)/60.0
             idx = np.abs(pix_res-sigma/5.0).argmin()
             nside = nsides[idx]
-        
+
         # get everything in the right units
         center_phi = cls._ra_to_phi(center_ra)
         center_theta = cls._dec_to_theta(center_dec)
         radius_rad = np.deg2rad(radius)
         sigma_rad = np.deg2rad(sigma)
 
-        # number of points in the circle based on the approximate arclength 
+        # number of points in the circle based on the approximate arclength
         # and resolution
         res = hp.nside2resol(nside)
-        
+
         # calculate normal distribution about annulus radius with sigma width
         x = np.linspace(0.0, np.pi, int(10.0*np.pi/res))
         pdf = norm.pdf(x, loc=radius_rad, scale=sigma_rad)
 
-        # cycle through annuli of radii from 0 to 180 degree with the 
+        # cycle through annuli of radii from 0 to 180 degree with the
         # appropriate amplitude and fill the probability map
         probmap = np.zeros(hp.nside2npix(nside))
         for i in range(x.size):
             # no need to waste time on pixels that will have ~0 probability...
             if pdf[i]/pdf.max() < 1e-10:
                 continue
-            
+
             # approximate arclength determines number of points in each annulus
             arclength = 2.0*np.pi*x[i]
             numpts = int(np.ceil(arclength/res))*10
             circ = sky_circle(center_phi, center_theta, x[i], num_points=numpts)
             theta = np.pi / 2.0 - circ[1]
             phi = circ[0]
-            
+
             # convert to pixel indixes and fill the map
             idx = hp.ang2pix(nside, theta, phi)
             probmap[idx] = pdf[i]
@@ -726,20 +725,20 @@ class HealPixLocalization(HealPix):
             probmap[idx[~mask]] = pdf[i]
             probmap[idx[mask]] = (probmap[idx[mask]] + pdf[i])/2.0
 
-        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename, 
+        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename,
                             **kwargs)
         return obj
 
     @classmethod
     def from_data(cls, prob_arr, trigtime=None, filename=None, **kwargs):
         """Create a HealPixLocalization object from a HEALPix probability array.
-        
+
         Args:
             prob_arr (np.array): The HEALPix array
             trigtime (float, optional): The reference time for the map
             filename (str, optional): The filename
-        
-        Returns:        
+
+        Returns:
             (:class:`HealPixLocalization`)
         """
         obj = super().from_data(prob_arr, trigtime=trigtime, filename=filename,
@@ -749,21 +748,21 @@ class HealPixLocalization(HealPix):
         return obj
 
     @classmethod
-    def from_gaussian(cls, center_ra, center_dec, sigma, nside=None, 
+    def from_gaussian(cls, center_ra, center_dec, sigma, nside=None,
                       trigtime=None, filename=None, **kwargs):
         """Create a HealPixLocalization object of a Gaussian
-        
+
         Args:
             center_ra (float): The RA of the center of the Gaussian
             center_dec (float): The Dec of the center of the Gaussian
             sigma (float): The Gaussian standard deviation, in degrees
             nside (int, optional): The nside of the HEALPix to make. By default,
-                                   the nside is automatically determined by the 
-                                   `sigma` of the Gaussian.  Set this argument 
-                                   to override the default. 
+                                   the nside is automatically determined by the
+                                   `sigma` of the Gaussian.  Set this argument
+                                   to override the default.
             trigtime (float, optional): The reference time for the map
             filename (str, optional): The filename
-        
+
         Returns:
             (:class:`HealPixLocalization`)
         """
@@ -786,7 +785,7 @@ class HealPixLocalization(HealPix):
             pix_res = hp.nside2resol(nsides, True)/60.0
             idx = np.abs(pix_res-sigma/10.0).argmin()
             nside = nsides[idx]
-        
+
         # get everything in the right units
         center_phi = cls._ra_to_phi(center_ra)
         center_theta = cls._dec_to_theta(center_dec)
@@ -800,24 +799,24 @@ class HealPixLocalization(HealPix):
         # then smooth out using appropriate gaussian kernel
         probmap = hp.smoothing(probmap, sigma=sigma_rad)
 
-        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename, 
+        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename,
                             **kwargs)
         return obj
 
     @classmethod
-    def from_vertices(cls, ra_pts, dec_pts, nside=64, trigtime=None, 
+    def from_vertices(cls, ra_pts, dec_pts, nside=64, trigtime=None,
                       filename=None, **kwargs):
         """Create a HealPixLocalization object from a list of RA, Dec vertices.
         The probability within the vertices will be distributed uniformly and
         zero probability outside the vertices.
-        
+
         Args:
             ra_pts (np.array): The array of RA coordinates
             dec_pts (np.array): The array of Dec coordinates
             nside (int, optional): The nside of the HEALPix to make. Default is 64.
             trigtime (float, optional): The reference time for the map
             filename (str, optional): The filename
-        
+
         Returns:
             (:class:`HealPixLocalization`)
         """
@@ -825,7 +824,7 @@ class HealPixLocalization(HealPix):
         dec_pts = np.asarray(dec_pts)
         if np.any((dec_pts < -90.0) | (dec_pts > 90.0)):
             raise ValueError('all dec_pts must be between -90 and 90')
-                
+
         poly = Polygon(np.vstack((ra_pts, dec_pts)).T, closed=True)
 
         npix = hp.nside2npix(nside)
@@ -836,7 +835,7 @@ class HealPixLocalization(HealPix):
 
         probmap = np.zeros(npix)
         probmap[mask] = 1.0
-        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename, 
+        obj = cls.from_data(probmap, trigtime=trigtime, filename=filename,
                             **kwargs)
         return obj
 
@@ -844,11 +843,11 @@ class HealPixLocalization(HealPix):
     def _credible_levels(p):
         """Calculate the credible levels of a probability array using a greedy
         algorithm.
-    
+
         Args:
             p (np.array): The probability array
-    
-        Returns:    
+
+        Returns:
              (np.array)
         """
         p = np.asarray(p)


### PR DESCRIPTION
Matplotlib updated their API in 3.10, which breaks plotting of contours from localization HEALPix objects.  This PR updates to using the API call required in Matplotlib 3.10.