### PR TITLE
Update HEASARC Catalog Link

### DIFF
--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -805,7 +805,7 @@ class BrowseCatalog:
 
         # build the URL query
         host = 'https://heasarc.gsfc.nasa.gov'
-        script = 'db-perl/W3Browse/w3query.pl'
+        script = 'cgi-bin/W3Browse/w3query.pl'
         query = 'tablehead=name=BATCHRETRIEVALCATALOG_2.0+'
         # Retrieve all fields, all rows, and return in FITS format
         query += '{}&Fields=All&displaymode=FitsDisplay&ResultMax=0'.format(table)


### PR DESCRIPTION
This PR updates the https address in GDT's HEASARC catalog interface to use "cgi-bin" instead of "db-perl". Doing so fixes the catalog unit tests which are currently failing with Error 503.

I'm currently waiting on a response from HEASARC to confirm that this change is intentional. We should hold off on merging this PR until we get confirmation.