### PR TITLE
Added support for retrieving HEASARC data from AWS servers

### DIFF
--- a/docs/core/heasarc.rst
+++ b/docs/core/heasarc.rst
@@ -20,11 +20,11 @@ HEASARC Data Finders and Catalog Access (:mod:`gdt.core.heasarc`)
     check for data availability on AWS by copying a HEASARC directory path from the
     FTP servers and converting it to an AWS link like so:
 
-    https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2025/bn250611560/current/
+    https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2025/bn250611560/current
 
     becomes
 
-    https://nasa-heasarc.s3.amazonaws.com/?list-type=2&prefix=fermi/data/gbm/triggers/2025/bn250101395/
+    https://nasa-heasarc.s3.amazonaws.com/?list-type=2&prefix=fermi/data/gbm/triggers/2025/bn250611560/current
 
     which provides the list of available directory files in XML format.
 

--- a/docs/core/heasarc.rst
+++ b/docs/core/heasarc.rst
@@ -11,12 +11,30 @@
 HEASARC Data Finders and Catalog Access (:mod:`gdt.core.heasarc`)
 ******************************************************************
 
+.. warning::
+    HEASARC is currently experiencing a high load on their main HTTPS servers.
+    Users experiencing issues should try switching to the AWS protocol described
+    below.
+
+    Note that **only a subset of HEASARC data are available on AWS**. Users can manually
+    check for data availability on AWS by copying a HEASARC directory path from the
+    FTP servers and converting it to an AWS link like so:
+
+    https://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2025/bn250611560/current/
+
+    becomes
+
+    https://nasa-heasarc.s3.amazonaws.com/?list-type=2&prefix=fermi/data/gbm/triggers/2025/bn250101395/
+
+    which provides the list of available directory files in XML format.
+
 Introduction
 ============
 The High-Energy Astrophysics Science Archive Research Center (HEASARC) is a
 repository for data and catalogs for many high-energy astrophysics
 missions.  Science and auxiliary data files are hosted on FTP and HTTPS servers, while
 a variety of catalogs are accessible via the HEASARC's Browse interface.
+Additionally, a subset of HEASARC data are mirrored on Amazon Web Services.
 
 The GDT provides a base class for accessing and navigating the directories
 of mission data, as well as a base class for interfacing with catalogs on 
@@ -36,8 +54,11 @@ the directory structure may be organized such that navigating it manually is
 a nuisance. By inheriting the BaseFinder and defining one function, we can
 immediately access the data we need and download it for a given mission.
 
-|BaseFinder| offers file access through either HTTPS or FTP protocols. The
-default protocol is HTTPS, which is recommended due to its wider support
+|BaseFinder| offers file access to the main HEASARC servers through either
+HTTPS or FTP protocols. Additionally, an AWS protocol is available for accessing
+the subset of HEASARC data mirrored on Amazon Web Services. Users should take
+care when using the AWS protocol since not all HEASARC data is available through AWS
+at this time. The default protocol is HTTPS, which is recommended due to its wider support
 across secure networks as well as the higher reliability of HEASARC's HTTPS
 servers. If necessary, the protocol type can be selected manually by passing a
 ``protocol`` keyword during initialization of classes derived from BaseFinder.
@@ -123,10 +144,11 @@ different directory, you can do that too:
    'glg_cspec_b1_bn090510016_v00.rsp2',
    ...]
 
-Finally, you can enable file transfer over FTP instead of
+Finally, you can enable file transfer over FTP or AWS instead of
 HTTPS by setting the protocol keyword argument:
 
   >>> finder = MyFinder('170817529', protocol='FTP')
+  >>> finder = MyFinder('170817529', protocol='AWS')
 
 However, it is recommended that you use the default HTTPS setting for
 HEASARC.

--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -599,7 +599,6 @@ class Aws(Http):
         Returns:
             (list of str)
         """
-        print("Aws _ls", path)
         files = []
         page = urlopen(self.urljoin("?list-type=2&prefix=" + path.lstrip("/")), context=self._context)
         table = page.read().decode("utf-8").split(self._table_key)[1]

--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -603,7 +603,7 @@ class Aws(Http):
         page = urlopen(self.urljoin("?list-type=2&prefix=" + path.lstrip("/")), context=self._context)
         table = page.read().decode("utf-8").split(self._table_key)[1]
         for line in table.split(self._start_key)[1:]:
-            file = line.split(self._end_key)[0]
+            file = os.path.basename(line.split(self._end_key)[0])
             files.append(os.path.join(path, file))
         return files
 

--- a/tests/core/test_heasarc.py
+++ b/tests/core/test_heasarc.py
@@ -170,10 +170,15 @@ class TestFinder(TestMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._test_protocols = ['FTP', 'HTTPS']
+        cls._test_protocols = ['FTP', 'HTTPS', 'AWS']
         if os.environ.get('SKIP_HEASARC_FTP_TESTS', False):
             print('Skipping HEASARC FTP tests')
-            cls._test_protocols = ['HTTPS']
+            i = cls._test_protocols.index("FTP")
+            cls._test_protocols.pop(i)
+        if os.environ.get('SKIP_HEASARC_HTTP_TESTS', False):
+            print('Skipping HEASARC HTTP/HTTPS tests')
+            i = cls._test_protocols.index("HTTPS")
+            cls._test_protocols.pop(i)
 
     def test_initialize(self):
         for protocol in self._test_protocols:
@@ -212,7 +217,7 @@ class TestFinder(TestMixin, unittest.TestCase):
 
 
     def test_errors(self):
-        keyword = {"HTTP": "url", "HTTPS": "url", "FTP": "host"}
+        keyword = {"HTTP": "url", "HTTPS": "url", "FTP": "host", "AWS": "url"}
         for protocol in self._test_protocols:
             with self.assertRaises(ValueError):
                 MyFinder('oops i did it again', protocol=protocol)
@@ -255,6 +260,9 @@ class TestFileDownloader(TestMixin, unittest.TestCase):
             pass
 
 
+@unittest.skipIf(
+    os.environ.get('SKIP_HEASARC_HTTP_TESTS', False), 'Skipping HEASARC HTTP/HTTPS tests'
+)
 class TestBrowseCatalog(unittest.TestCase):
     
     @classmethod


### PR DESCRIPTION
This pull request adds a new protocol class, `Aws()`, that derives from the `Http()` protocol class. The new class updates the internal `_ls()` method with parsing for file paths in the XML index provided via the s3 AWS format. 

This allows us to access HEASARC data over HTTPS on the AWS servers.

To Do Before Merging:
1. Add unit tests
2. Look at updating Sphinx documentation

Once gdt-core is updated, the changes will propagate to all instrument finders that inherit from BaseFinder. For example, gdt-fermi users will be able to do:

```
from gdt.missions.fermi.gbm.finders import TriggerFinder

finder = TriggerFinder("250611560", protocol="AWS")
finder.get_trigdat(".")
```
without needing to update gdt-fermi.