### PR TITLE
Fix the finder behavior when using the AWS protocol to search directories instead of files

### DIFF
--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -603,8 +603,17 @@ class Aws(Http):
         page = urlopen(self.urljoin("?list-type=2&prefix=" + path.lstrip("/")), context=self._context)
         table = page.read().decode("utf-8").split(self._table_key)[1]
         for line in table.split(self._start_key)[1:]:
-            file = os.path.basename(line.split(self._end_key)[0])
-            files.append(os.path.join(path, file))
+            full_path = line.split(self._end_key)[0]
+            dirname = os.path.dirname(full_path)
+            file = os.path.basename(full_path)
+            if path.lstrip("/").rstrip("/") != dirname:
+                # return base directory when searching an upper level directory
+                full_dir = os.path.join(path, os.path.basename(dirname))
+                if full_dir not in files:
+                    files.append(full_dir)
+            else:
+                # otherwise return the file name
+                files.append(os.path.join(path, file))
         return files
 
 

--- a/tests/core/test_heasarc.py
+++ b/tests/core/test_heasarc.py
@@ -125,6 +125,9 @@ class TestFtp(TestMixin, unittest.TestCase):
         self.assertEqual(str(protocol), '<Ftp: host heasarc.gsfc.nasa.gov>')
 
 
+@unittest.skipIf(
+    os.environ.get('SKIP_HEASARC_HTTP_TESTS', False), 'Skipping HEASARC HTTP tests'
+)
 class TestHttp(TestMixin, unittest.TestCase):
 
     def test_download_url(self):
@@ -238,22 +241,26 @@ class TestFinder(TestMixin, unittest.TestCase):
                 pass
 
     def test_repr(self):
-        finder = MyFinder('170817529')
-        self.assertEqual(str(finder), '<MyFinder: 170817529>')
+        for protocol in self._test_protocols:
+            finder = MyFinder('170817529', protocol=protocol)
+            self.assertEqual(str(finder), '<MyFinder: 170817529>')
 
 class TestFileDownloader(TestMixin, unittest.TestCase):
 
     def test_download(self):
         downloader = FileDownloader()
-        downloader.download_url(self.https_urls[0], this_dir)
-        downloader.download_url(self.ftp_urls[0], this_dir)
+        if not os.environ.get('SKIP_HEASARC_HTTP_TESTS', False):
+            downloader.download_url(self.https_urls[0], this_dir)
+        if not os.environ.get('SKIP_HEASARC_FTP_TESTS', False):
+            downloader.download_url(self.ftp_urls[0], this_dir)
 
         with self.assertRaises(ValueError):
             downloader.download_url('bad', this_dir)
 
     def test_bulk(self):
         downloader = FileDownloader()
-        downloader.bulk_download(self.https_urls, this_dir)
+        if not os.environ.get('SKIP_HEASARC_HTTP_TESTS', False):
+            downloader.bulk_download(self.https_urls, this_dir)
 
     def test_context(self):
         with FileDownloader() as downloader:


### PR DESCRIPTION
The initial implementation assumed a finder using the AWS protocol would always be searching for files within a directory. As a result, it used
```
file = os.path.basename(line.split(self._end_key)[0])
```
to grab the basename of the file from the AWS path entry. This is needed because AWS always returns the full path to all files below the requested directory point.

However, some finders such as the BATSE data finders first perform a search for the appropriate trigger directory. This PR adds parsing for cases where the user is trying to retrieve a list of subdirectories rather than files.

This PR also fixes a few cases with test_heasarc.py where we weren't skipping FTP/HTTP tests as requested.