### PR TITLE
Added links to GitHub repo and related pages (issues, pull requests) to documents

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,8 +4,9 @@
 Contributing to the GDT
 =======================
 Community contributions to the GDT are welcome and make the GDT a better 
-toolkit for everyone to use.  There are various types of contributions.  These 
-include:
+toolkit for everyone to use. You can contribute via our 
+`GitHub repository <https://github.com/USRA-STI/gdt-core>`_ .  There are 
+various types of contributions. These include:
 
 * Bug fixes
 * New features
@@ -13,7 +14,8 @@ include:
 * API improvements
 * New mission packages
 
-For each contribution, we consider it best practice to first open an issue (with
+For each contribution, we consider it best practice to first 
+`open an issue <https://github.com/USRA-STI/gdt-core/issues>`_ (with
 an appropriate ``label``).  This may be as simple as notifying us (and other 
 users!) that there is a bug.  Perhaps you also have a proposed solution to 
 fixing the issue.  If so, then you can outline your proposed fix when you open 
@@ -39,12 +41,15 @@ covered by an existing unit test.
 
 The usual sequence of events are:
 
-1. Create an issue describing the proposed changes.
-2. Waiting for feedback if desired.
-3. Fork from main branch.
+1. `Create an issue <https://github.com/USRA-STI/gdt-core/issues>`_ describing 
+the proposed changes.
+2. Wait for feedback if desired.
+3. Fork from `main branch <https://github.com/USRA-STI/gdt-core>`_.
 4. Use your fork to add your changes to the code base.
 5. Create unit tests showing that your changes work as intended.
-6. Create a `Pull Request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_ with a comment explaining how it closes the issue you created.
+6. Create a `Pull Request <https://github.com/USRA-STI/gdt-core/pulls>`_ with a 
+comment explaining how it closes the issue you created. If you've never opened one before, 
+GitHub has a `helpful guide <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_ on creating a pull request.
 
 
 Opening an Issue

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,9 @@ The Gamma-ray Data Tools (GDT) is centralized toolkit for hard X-ray and
 gamma-ray astrophysics data analysis, with a focus on providing a uniform 
 interface to the data provided by several different missions and instruments.
 
-The GDT Core Package (``gdt-core``) contains the core components of the GDT that
-can be utilized for various instruments and is a generalized version of the
+The `GDT Core Package <https://github.com/USRA-STI/gdt-core>`_ (``gdt-core``) 
+contains the core components of the GDT that can be utilized for various instruments 
+and is a generalized version of the
 `Fermi GBM Data Tools <https://fermi.gsfc.nasa.gov/ssc/data/analysis/gbm/gbm_data_tools/gdt-docs>`_.
 Individual mission or instrument packages can be developed using the ``gdt-core`` 
 and released under the ``gdt`` namespace (see ``gdt-fermi`` as an example).


### PR DESCRIPTION
I'm really excited that this package exists, and overall it works great! I have a couple of small bug fixes I'd like to contribute, and the first thing I noticed was that I had trouble actually finding the GitHub repo. As far as I can tell, in the entire set of docs pages, the link to the repo only exists in the citation. So I added some helpful links to the `index.rst` and to the contributing page, where I'd expect easy access. Suggestions of course welcome.