### PR TITLE
Moved setting the x-axis limits to after the axes were configured acc…

### DIFF
--- a/src/gdt/core/plot/spectrum.py
+++ b/src/gdt/core/plot/spectrum.py
@@ -139,7 +139,6 @@ class Spectrum(GdtPlot):
         self._errorbars = HistoErrorbars(data, self._ax, color=eb_color,
                                          alpha=eb_alpha, **eb_kwargs)
 
-        self._ax.set_xlim(data.range)
         mask = (data.rates > 0.0)
         
         if isinstance(data, ChannelBins):
@@ -151,7 +150,10 @@ class Spectrum(GdtPlot):
         else:
             self._ax.set_ylim(0.9 * data.rates_per_kev[mask].min(),
                               1.1 * data.rates_per_kev.max())
-    
+
+        self._ax.set_xlim(data.range)
+
+
     def remove_background(self):
         """Remove the background from the plot.
         """


### PR DESCRIPTION
This fixes the non-positive number warning described in #97 by waiting until after the plot axes are configured according to input data type before setting the x-axis limits.