### PR TITLE
Fix tte deadtime

### DIFF
--- a/src/gdt/core/tte.py
+++ b/src/gdt/core/tte.py
@@ -47,12 +47,12 @@ class PhotonList(FitsFileContextManager):
         self._trigtime = None
         self._event_deadtime = 0.0
         self._overflow_deadtime = 0.0
-    
+
     @property
     def data(self):
         """(:class:`~.data_primitives.EventList`): The event data"""
         return self._data
-    
+
     @property
     def ebounds(self):
         """(:class:`~.data_primitives.Ebounds`): The energy-channel mapping"""
@@ -62,17 +62,17 @@ class PhotonList(FitsFileContextManager):
     def energy_range(self):
         """(float, float): The energy range of the data"""
         return self._data.energy_range
-    
+
     @property
     def event_deadtime(self):
         """(float): The deadtime imposed per event"""
         return self._event_deadtime
-    
+
     @property
     def gti(self):
         """(:class:`~.data_primitives.Gti`): The good time intervals"""
         return self._gti
-    
+
     @property
     def num_chans(self):
         """(int): The number of energy channels"""
@@ -80,10 +80,10 @@ class PhotonList(FitsFileContextManager):
 
     @property
     def overflow_deadtime(self):
-        """(float): The per-event deadtime imposed by events in the overflow 
+        """(float): The per-event deadtime imposed by events in the overflow
         channel"""
         return self._overflow_deadtime
-    
+
     @property
     def time_range(self):
         """(float, float): The time range of the data"""
@@ -98,65 +98,65 @@ class PhotonList(FitsFileContextManager):
         """Calculate the total exposure of a time range or time ranges of data.
 
         Args:
-            time_ranges ([(float, float), ...], optional): 
-                The time range or time ranges over which to calculate the 
+            time_ranges ([(float, float), ...], optional):
+                The time range or time ranges over which to calculate the
                 exposure. If omitted, calculates the total exposure of the data.
-        
-        Returns:        
+
+        Returns:
             (float)
         """
         if time_ranges is None:
             time_ranges = self.time_range
         time_ranges = self._assert_range_list(time_ranges)
-        exposure = self._data.get_exposure(time_ranges=time_ranges, 
+        exposure = self._data.get_exposure(time_ranges=time_ranges,
                                            event_deadtime=self.event_deadtime,
                                            overflow_deadtime=self.overflow_deadtime)
         return exposure
 
     def rebin_energy(self, method, *args, **kwargs):
-        """Rebin the PhotonList in energy given a rebinning method. 
+        """Rebin the PhotonList in energy given a rebinning method.
         Produces a new PhotonList object.
 
         Args:
             method (<function>): The rebinning function
             *args: Arguments to be passed to the rebinning function
-        
-        Returns        
+
+        Returns
             (:class:`PhotonList`)
         """
-        data = self._data.rebin_energy(method, *args, 
+        data = self._data.rebin_energy(method, *args,
                                        event_deadtime=self.event_deadtime,
                                        overflow_deadtime=self.overflow_deadtime)
-        headers = self._build_headers(self.trigtime, *data.time_range, 
+        headers = self._build_headers(self.trigtime, *data.time_range,
                                       data.num_chans)
-        obj = self.from_data(data, gti=self.gti, trigger_time=self.trigtime, 
-                             headers=headers, 
+        obj = self.from_data(data, gti=self.gti, trigger_time=self.trigtime,
+                             headers=headers,
                              event_deadtime=self.event_deadtime,
                              overflow_deadtime=self.overflow_deadtime, **kwargs)
         return obj
 
     def set_ebounds(self, ebounds):
-        """Set the energy calibration (ebounds) of the data. If the data already 
-        has an energy calibration, this method will update the calibration to 
+        """Set the energy calibration (ebounds) of the data. If the data already
+        has an energy calibration, this method will update the calibration to
         the new ebounds.
-        
+
         Args:
             ebounds (:class:`~.data_primitives.Ebounds`): The ebounds
         """
-        self.data.ebounds = ebounds        
+        self.data.ebounds = ebounds
 
     def slice_energy(self, energy_ranges, **kwargs):
-        """Slice the PhotonList by one or more energy ranges. Produces a new 
+        """Slice the PhotonList by one or more energy ranges. Produces a new
         PhotonList object.
 
         Note::
           If the data does not have an energy calibration (ebounds), then this
-          function will slice by energy channels, and therefore the 
+          function will slice by energy channels, and therefore the
           ``energy_ranges`` argument should be a range(s) of energy channels
           instead of energies.
-        
+
         Args:
-            energy_ranges ([(float, float), ...]): 
+            energy_ranges ([(float, float), ...]):
                 The energy ranges to slice the data to.
 
         Returns:
@@ -171,68 +171,68 @@ class PhotonList(FitsFileContextManager):
                     for energy_range in energy_ranges]
         data = EventList.merge(data, sort=True)
 
-        headers = self._build_headers(self.trigtime, *data.time_range, 
+        headers = self._build_headers(self.trigtime, *data.time_range,
                                       data.num_chans)
         tte = self.from_data(data, gti=self.gti, trigger_time=self.trigtime,
-                             headers=headers, 
+                             headers=headers,
                              event_deadtime=self.event_deadtime,
                              overflow_deadtime=self.overflow_deadtime, **kwargs)
         return tte
 
     def slice_time(self, time_ranges, **kwargs):
-        """Slice the PhotonList by one or more time range. Produces a new 
+        """Slice the PhotonList by one or more time range. Produces a new
         PhotonList object.
-        
+
         Args:
-            time_ranges ([(float, float), ...]): 
+            time_ranges ([(float, float), ...]):
                 The time ranges to slice the data to.
-        
+
         Returns:
             (:class:`PhotonList`)
         """
         time_ranges = self._assert_range_list(time_ranges)
         data = [self.data.time_slice(*self._assert_range(time_range)) \
                 for time_range in time_ranges]
-        
+
         gti = Gti.from_list(self.gti.as_list())
-        for segment in data: 
+        for segment in data:
             seg_gti = Gti.from_list([segment.time_range])
             gti = Gti.intersection(gti, seg_gti)
-        
+
         data = EventList.merge(data, sort=True)
 
-        headers = self._build_headers(self.trigtime, *data.time_range, 
-                                      data.num_chans)        
+        headers = self._build_headers(self.trigtime, *data.time_range,
+                                      data.num_chans)
         tte = self.from_data(data, gti=gti, trigger_time=self.trigtime,
-                             headers=headers, 
+                             headers=headers,
                              event_deadtime=self.event_deadtime,
                              overflow_deadtime=self.overflow_deadtime, **kwargs)
-        
+
         return tte
-    
+
     def to_pha(self, time_ranges=None, energy_range=None, channel_range=None,
                **kwargs):
-        """Integrate the PhotonList data over one or more time ranges to 
+        """Integrate the PhotonList data over one or more time ranges to
         produce a PHA object
 
         Note::
-          If the data does not have an energy calibration (ebounds), then a 
+          If the data does not have an energy calibration (ebounds), then a
           PHA object cannot be created and calling this method will raise an
           exception.
 
         Args:
-            time_ranges ([(float, float), ...], optional): 
-                The time range of the spectrum. If omitted, uses the entire 
+            time_ranges ([(float, float), ...], optional):
+                The time range of the spectrum. If omitted, uses the entire
                 time range of the data.
-            energy_range ((float, float), optional): 
-                The energy range of the spectrum. If omitted, uses the entire 
+            energy_range ((float, float), optional):
+                The energy range of the spectrum. If omitted, uses the entire
                 energy range of the data.
-            channel_range ((int, int), optional): 
-                The channel range of the spectrum. If omitted, uses the entire 
+            channel_range ((int, int), optional):
+                The channel range of the spectrum. If omitted, uses the entire
                 energy range of the data.
 
             **kwargs: Options passed to :meth:`.pha.PHA.from_data`
-        
+
         Returns:
             (:class:`~.pha.PHA`)
         """
@@ -258,54 +258,54 @@ class PhotonList(FitsFileContextManager):
             himask = (idx > channel_range[1])
         else:
             lomask = himask = np.zeros(self.num_chans, dtype=bool)
-        
+
         data = el.count_spectrum(event_deadtime=self.event_deadtime,
                                  overflow_deadtime=self.overflow_deadtime)
         # values for the PHA object
         channel_mask = ~(lomask | himask)
-        
+
         gti = Gti.from_list(times)
-        
-        pha = Pha.from_data(data, gti=gti, trigger_time=self.trigtime, 
+
+        pha = Pha.from_data(data, gti=gti, trigger_time=self.trigtime,
                             channel_mask=channel_mask, **kwargs)
 
         return pha
 
     def to_phaii(self, bin_method, *args, time_range=None, energy_range=None,
                  channel_range=None, phaii_class=Phaii, headers=None, **kwargs):
-        """Convert the PhotonList data to PHAII data by binning the data in 
+        """Convert the PhotonList data to PHAII data by binning the data in
         time.
 
         Note::
-          If the data has no energy calibration, then ``energy_range`` is 
+          If the data has no energy calibration, then ``energy_range`` is
           ignored, and only ``channel_range`` is used.
-        
+
         Args:
             bin_method (<function>): A binning function for unbinned data
             *args: Arguments to pass to the binning function
             time_range ([(float, float), ...], optional):
-                The time range of the spectrum. If omitted, uses the entire 
+                The time range of the spectrum. If omitted, uses the entire
                 time range of the data.
-            energy_range ((float, float), optional): 
-                The energy range of the spectrum. If omitted, uses the entire 
+            energy_range ((float, float), optional):
+                The energy range of the spectrum. If omitted, uses the entire
                 energy range of the data.
-            channel_range ((int, int), optional): 
-                The channel range of the spectrum. If omitted, uses the entire 
+            channel_range ((int, int), optional):
+                The channel range of the spectrum. If omitted, uses the entire
                 energy range of the data.
-            phaii_class (class): The Phaii subclass that the data will be 
-                                 converted to.  Default is the base 
+            phaii_class (class): The Phaii subclass that the data will be
+                                 converted to.  Default is the base
                                  :class:`~.phaii.Phaii` class.
-            headers (:class:`~.headers.FileHeaders`, optional): 
-                The PHAII headers 
+            headers (:class:`~.headers.FileHeaders`, optional):
+                The PHAII headers
             **kwargs: Options to pass to the binning function
-        
+
         Returns:
             (:class:`~.phaii.Phaii`)
         """
         if not issubclass(phaii_class, Phaii):
             raise TypeError('phaii_class must be set to a functional Phaii ' \
                             'derived class.')
-        
+
         # slice to desired energy or channel range
         if (channel_range is not None) or (energy_range is not None):
             if channel_range is not None:
@@ -319,11 +319,11 @@ class PhotonList(FitsFileContextManager):
                 if channel_range is None:
                     channel_range = self.data.channel_range
                 energy_range = channel_range
-                    
+
             obj = self.slice_energy(energy_ranges=self._assert_range(energy_range))
         else:
             obj = self
-        
+
         # slice to desired time range
         if time_range is None:
             pass
@@ -331,11 +331,12 @@ class PhotonList(FitsFileContextManager):
             obj = obj.slice_time(time_range)
 
         # do the time binning to create the TimeEnergyBins or TimeChannelBins
-        bins = obj.data.bin(bin_method, *args, **kwargs)
+        bins = obj.data.bin(bin_method, *args, event_deadtime=self._event_deadtime,
+                            overflow_deadtime=self._overflow_deadtime, **kwargs)
         if (energy_range is not None) and (self.ebounds is not None):
             bins = bins.slice_energy(*energy_range)
-        
-        phaii = phaii_class.from_data(bins, gti=obj.gti, 
+
+        phaii = phaii_class.from_data(bins, gti=obj.gti,
                                       trigger_time=obj.trigtime,
                                       headers=headers, **kwargs)
         return phaii
@@ -346,23 +347,23 @@ class PhotonList(FitsFileContextManager):
 
         Args:
             time_range ((float, float), optional):
-                The time range of the spectrum. If omitted, uses the entire 
+                The time range of the spectrum. If omitted, uses the entire
                 time range of the data.
-            energy_range ((float, float), optional): 
-                The energy range of the spectrum. If omitted, uses the entire 
+            energy_range ((float, float), optional):
+                The energy range of the spectrum. If omitted, uses the entire
                 energy range of the data.
-            channel_range ((int, int), optional): 
-                The channel range of the spectrum. If omitted, uses the entire 
+            channel_range ((int, int), optional):
+                The channel range of the spectrum. If omitted, uses the entire
                 energy range of the data.
 
         Returns:
             (:class:`~.data_primitives.EnergyBins`)
         """
-        # slice to desired energy or channel range   
+        # slice to desired energy or channel range
         if (channel_range is not None) or (energy_range is not None):
             if channel_range is not None:
                 self._assert_range(channel_range)
-                
+
             if self.ebounds is not None:
                 if channel_range is not None:
                     energy_range = (self.ebounds.low_edges()[channel_range[0]],
@@ -374,49 +375,49 @@ class PhotonList(FitsFileContextManager):
                 temp = self.data.channel_slice(*channel_range)
         else:
             temp = self._data
-        
+
         # time slice
         if time_range is None:
             time_range = self.time_range
         segment = temp.time_slice(*self._assert_range(time_range))
-        
+
         spec = segment.count_spectrum()
         return spec
-       
+
     @classmethod
     def from_data(cls, data, gti=None, trigger_time=None, filename=None,
                   headers=None, event_deadtime=0.0, overflow_deadtime=0.0,
                   **kwargs):
-        """Create a PhotonList object from an 
+        """Create a PhotonList object from an
         :class:`~.data_primitives.EventList` object.
 
         Args:
             data (:class:`~.data_primitives.EventList`): The event data
-            gti (:class:`~.data_primitives.Gti`, optional): 
-                The Good Time Intervals object. If omitted, the GTI spans 
-                (tstart, tstop) 
-            trigger_time (float, optional): 
-                The trigger time, if applicable. If provided, the data times 
+            gti (:class:`~.data_primitives.Gti`, optional):
+                The Good Time Intervals object. If omitted, the GTI spans
+                (tstart, tstop)
+            trigger_time (float, optional):
+                The trigger time, if applicable. If provided, the data times
                 will be shifted relative to the trigger time.
             filename (str): The filename
             headers (:class:`~.headers.FileHeaders`): The file headers
             event_deadtime (float, optional): The deadtime imposed per event.
                                               Default is 0.0.
-            overflow_deadtime (float, optional): The per-event deadtime imposed 
-                                                 by events in the overflow 
+            overflow_deadtime (float, optional): The per-event deadtime imposed
+                                                 by events in the overflow
                                                  channel. Default is 0.0.
-        
+
         Returns:
             (:class:`PhotonList`)
         """
         obj = cls()
         obj._filename = filename
-        
+
         # set data
         if not isinstance(data, EventList):
             raise TypeError('data must be of type EventList')
         obj._data = data
-        
+
         # set GTI
         if gti is not None:
             if not isinstance(gti, Gti):
@@ -424,18 +425,18 @@ class PhotonList(FitsFileContextManager):
         else:
             gti = Gti.from_list([data.time_range])
         obj._gti = gti
-                
+
         # set headers
         if headers is not None:
             if not isinstance(headers, FileHeaders):
                 raise TypeError('headers must be of type FileHeaders')
-        obj._headers = headers        
- 
+        obj._headers = headers
+
         if trigger_time is not None:
             if trigger_time < 0.0:
                 raise ValueError('trigger_time must be non-negative')
             obj._trigtime = trigger_time
-        
+
         try:
             event_deadtime = float(event_deadtime)
             overflow_deadtime = float(overflow_deadtime)
@@ -445,35 +446,35 @@ class PhotonList(FitsFileContextManager):
             raise ValueError('deadtime must be non-negative')
         obj._event_deadtime = event_deadtime
         obj._overflow_deadtime = overflow_deadtime
-       
+
         return obj
 
     @classmethod
     def merge(cls, ttes, primary=0, force_unique=True):
         """Merge a list of PhotonList objects into a single new PhotonList o
         bject.
-        
-        Warning: 
-            The amount of data in a single PhotonList object can be quite large. 
-            It is up to you to determine if you have enough memory to support 
+
+        Warning:
+            The amount of data in a single PhotonList object can be quite large.
+            It is up to you to determine if you have enough memory to support
             the merge.
-        
+
         Args:
             ttes (list): A list of PhotonList objects to merge
-            primary (int): 
-                The index into the list of PhotonList objects to designate the 
-                primary PhotonList object.  The primary object will be the 
-                reference for the header information for the new merged 
-                PhotonList object. Default is the first PhotonList object in 
+            primary (int):
+                The index into the list of PhotonList objects to designate the
+                primary PhotonList object.  The primary object will be the
+                reference for the header information for the new merged
+                PhotonList object. Default is the first PhotonList object in
                 the list (primary=0).
-            force_unique (bool, optional): 
-                If True, force all events to be unique via brute force sorting. 
-                If False, the EventLists will only be checked and masked for 
-                overlapping time ranges. Events can potentially be lost if the 
-                merged EventLists contain overlapping times (but not necessarily 
-                duplicate events), however this method is much faster.  
+            force_unique (bool, optional):
+                If True, force all events to be unique via brute force sorting.
+                If False, the EventLists will only be checked and masked for
+                overlapping time ranges. Events can potentially be lost if the
+                merged EventLists contain overlapping times (but not necessarily
+                duplicate events), however this method is much faster.
                 Default is True.
-        
+
         Returns:
             (:class:`PhotonList`)
         """
@@ -490,7 +491,7 @@ class PhotonList(FitsFileContextManager):
         if primary < 0 or primary > len(ttes)-1:
             raise ValueError('primary out of range for {} TTE objects' \
                              ''.format(len(ttes)))
-        
+
         # merge the Event data
         data = [tte.data for tte in ttes]
         data = EventList.merge(data, sort=True, force_unique=force_unique)
@@ -500,11 +501,11 @@ class PhotonList(FitsFileContextManager):
         merged_gti = gtis[0]
         for gti in gtis[1:]:
             merged_gti = Gti.merge(merged_gti, gti)
-            
+
         trigtime = ttes[primary].trigtime
 
         obj = cls.from_data(data, gti=merged_gti, trigger_time=trigtime,
-                            headers=ttes[primary].headers, 
+                            headers=ttes[primary].headers,
                             event_deadtime=ttes[primary].event_deadtime,
                             overflow_deadtime=ttes[primary].overflow_deadtime)
         return obj
@@ -527,14 +528,14 @@ class PhotonList(FitsFileContextManager):
         to be specified in the inherited class.  The method should construct
         the headers from the minimum required arguments and additional keywords
         and return a :class:`FileHeaders` object.
-        
+
         Args:
             trigtime (float or None): The trigger time.  Set to None if no
                                           trigger time.
             tstart (float): The start time
             tstop (float): The stop time
             num_chans (int): Number of detector energy channels
-        
+
         Returns:
             (:class:`~.headers.FileHeaders`)
         """

--- a/tests/core/test_tte.py
+++ b/tests/core/test_tte.py
@@ -35,30 +35,30 @@ from gdt.core.phaii import Phaii
 from gdt.core.pha import Pha
 from gdt.core.tte import PhotonList
 from gdt.core.binning.binned import combine_by_factor
-from gdt.core.binning.unbinned import bin_by_time
+from gdt.core.binning.unbinned import bin_by_time, combine_into_one
 
 class TestPhotonList(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
-        times = [0.706, 1.640, 3.185, 3.512, 5.540, 
+        times = [0.706, 1.640, 3.185, 3.512, 5.540,
                  7.790, 9.602, 9.726, 10.45, 10.61]
         chans = [4, 1, 0, 4, 5, 0, 4, 0, 2, 0]
-        ebounds = Ebounds.from_bounds([10.0, 20.0, 40.0, 80.0, 160.0, 320.0], 
+        ebounds = Ebounds.from_bounds([10.0, 20.0, 40.0, 80.0, 160.0, 320.0],
                                       [20.0, 40.0, 80.0, 160.0, 320.0, 640.0])
         data = EventList(times=times, channels=chans, ebounds=ebounds)
         gti = Gti.from_list([(0.0000, 10.70)])
-        cls.tte = PhotonList.from_data(data, gti=gti, 
+        cls.tte = PhotonList.from_data(data, gti=gti,
                                        trigger_time=356223561.133346,
-                                       event_deadtime=0.001, 
+                                       event_deadtime=0.001,
                                        overflow_deadtime=0.1)
-        
+
     def test_data(self):
         self.assertIsInstance(self.tte.data, EventList)
-    
+
     def test_ebounds(self):
         self.assertIsInstance(self.tte.ebounds, Ebounds)
-    
+
     def test_energy_range(self):
         self.assertTupleEqual(self.tte.energy_range, (10.0, 640.))
 
@@ -67,10 +67,10 @@ class TestPhotonList(unittest.TestCase):
 
     def test_filename(self):
         self.assertIsNone(self.tte.filename)
-    
+
     def test_gti(self):
         self.assertIsInstance(self.tte.gti, Gti)
-    
+
     def test_headers(self):
         self.assertIsNone(self.tte.headers)
 
@@ -79,17 +79,17 @@ class TestPhotonList(unittest.TestCase):
 
     def test_overflow_deadtime(self):
         self.assertEqual(self.tte.overflow_deadtime, 0.1)
-    
+
     def test_time_range(self):
         self.assertTupleEqual(self.tte.time_range, (0.706, 10.61))
-    
+
     def test_trigtime(self):
         self.assertEqual(self.tte.trigtime, 356223561.133346)
 
     def test_get_exposure(self):
         # total exposure
         self.assertAlmostEqual(self.tte.get_exposure(), 9.795)
-        
+
         # exposure of a time slice
         self.assertAlmostEqual(self.tte.get_exposure(time_ranges=(0.0, 5.0)),
                                4.996)
@@ -98,38 +98,38 @@ class TestPhotonList(unittest.TestCase):
         self.assertAlmostEqual(self.tte.get_exposure(time_ranges=[(0.0, 2.0),
                                                                     (5.0, 7.0)]),
                                3.898)
-    
+
     def test_rebin_energy(self):
         # full range
         rebinned_tte = self.tte.rebin_energy(combine_by_factor, 2)
-        self.assertEqual(rebinned_tte.num_chans, 3)        
-        
+        self.assertEqual(rebinned_tte.num_chans, 3)
+
     def test_set_ebounds(self):
         emin = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
         emax = [20.0, 30.0, 40.0, 50.0, 60.0, 70.0]
         ebounds = Ebounds.from_bounds(emin, emax)
-        
-        data = EventList(times=self.tte.data.times, 
+
+        data = EventList(times=self.tte.data.times,
                          channels=self.tte.data.channels)
-        tte = PhotonList.from_data(data, gti=self.tte.gti, 
+        tte = PhotonList.from_data(data, gti=self.tte.gti,
                                    trigger_time=self.tte.trigtime,
                                    event_deadtime=self.tte.event_deadtime,
                                    overflow_deadtime=self.tte.overflow_deadtime)
-    
+
         with self.assertRaises(TypeError):
             tte.set_ebounds(emin)
-                
+
         tte.set_ebounds(ebounds)
         assert isinstance(tte.ebounds, Ebounds)
         self.assertListEqual(tte.ebounds.low_edges(), emin)
         self.assertListEqual(tte.ebounds.high_edges(), emax)
-    
+
     def test_slice_energy(self):
         # one slice
         sliced_tte = self.tte.slice_energy((50.0, 250.0))
         self.assertTupleEqual(sliced_tte.energy_range, (40.0, 320.0))
         self.assertEqual(sliced_tte.num_chans, 6)
-        
+
         # multiple slices
         sliced_tte = self.tte.slice_energy([(25.0, 75.0), (250.0, 500.0)])
         self.assertTupleEqual(sliced_tte.energy_range, (20.0, 640.0))
@@ -140,7 +140,7 @@ class TestPhotonList(unittest.TestCase):
         sliced_tte = self.tte.slice_time((0.0, 5.0))
         self.assertTupleEqual(sliced_tte.time_range, (0.706, 3.512))
         self.assertEqual(sliced_tte.data.size, 4)
-        
+
         # multiple slices
         sliced_tte = self.tte.slice_time([(0.0, 2.0), (5.0, 7.0)])
         self.assertTupleEqual(sliced_tte.time_range, (0.706, 5.540))
@@ -155,44 +155,44 @@ class TestPhotonList(unittest.TestCase):
         # only create a slice of the spec
         spec = self.tte.to_spectrum(energy_range=(50.0, 300.0))
         self.assertListEqual(spec.counts.tolist(), [0, 0, 1, 0, 3, 0])
-        
+
         # or channels
         spec = self.tte.to_spectrum(channel_range=(3, 5))
         self.assertListEqual(spec.counts.tolist(), [0, 0, 0, 0, 3, 1])
-        
+
         # integrate over a part of the time range
         spec = self.tte.to_spectrum(time_range=(0.0, 5.0))
         self.assertListEqual(spec.counts.tolist(), [1, 1, 0, 0, 2, 0])
-    
+
     def test_to_pha(self):
-        
+
         # full time and energy range
         pha = self.tte.to_pha()
         self.assertIsInstance(pha, Pha)
         self.assertAlmostEqual(pha.exposure, 9.795)
         self.assertTupleEqual(pha.time_range, (0.706, 10.61))
         self.assertEqual(pha.num_chans, 6)
-        
+
         # integrate over time slice
         pha = self.tte.to_pha(time_ranges=(0.0, 5.0))
         self.assertAlmostEqual(pha.exposure, 2.802)
         self.assertTupleEqual(pha.time_range, (0.706, 3.512))
         self.assertEqual(pha.num_chans, 6)
-        
+
         # subset of the energy range
         pha = self.tte.to_pha(energy_range=(50.0, 300.0))
         self.assertAlmostEqual(pha.exposure, 9.74)
         self.assertTupleEqual(pha.time_range, (0.706, 10.61))
         self.assertEqual(pha.num_chans, 6)
         self.assertListEqual(pha.valid_channels.tolist(), [2, 3, 4])
-        
+
         # subset of the channel range
         pha = self.tte.to_pha(channel_range=(3, 5))
         self.assertAlmostEqual(pha.exposure, 8.793)
         self.assertTupleEqual(pha.time_range, (0.706, 10.61))
         self.assertEqual(pha.num_chans, 6)
         self.assertListEqual(pha.valid_channels.tolist(), [3, 4, 5])
-    
+
     def test_to_phaii(self):
         # full range
         phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii)
@@ -202,9 +202,9 @@ class TestPhotonList(unittest.TestCase):
         self.assertTupleEqual(phaii.time_range, (0.706, 10.706))
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 10)
-        
+
         # time range
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   time_range=(0.0, 5.0))
         self.assertTupleEqual(phaii.energy_range, self.tte.energy_range)
         self.assertTupleEqual(phaii.gti.as_list()[0], (0.706, 3.512))
@@ -212,9 +212,9 @@ class TestPhotonList(unittest.TestCase):
         self.assertTupleEqual(phaii.time_range, (0.706, 3.706))
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 3)
-        
+
         # energy range
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   energy_range=(10.0, 50.0))
         self.assertTupleEqual(phaii.energy_range, (10.0, 80.0))
         self.assertTupleEqual(phaii.gti.as_list()[0], self.tte.gti.as_list()[0])
@@ -223,33 +223,37 @@ class TestPhotonList(unittest.TestCase):
         self.assertEqual(phaii.data.num_times, 9)
 
         # channel range
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   channel_range=(0, 2))
         self.assertTupleEqual(phaii.energy_range, (10.0, 80.0))
         self.assertTupleEqual(phaii.gti.as_list()[0], self.tte.gti.as_list()[0])
         self.assertEqual(phaii.num_chans, 3)
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 9)
-        
+
+        # test application of deadtime
+        phaii = self.tte.to_phaii(combine_into_one, phaii_class=Phaii)
+        assert round(phaii.data.exposure[0], 7) == 9.795
+
         # bad time range
         with self.assertRaises(AssertionError):
-            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                               time_range=(1.0, 0.0))
 
         # bad energy range
         with self.assertRaises(AssertionError):
-            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                               energy_range=(1.0, 0.0))
-       
+
         # bad channel range
         with self.assertRaises(AssertionError):
-            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                               channel_range=(1.0, 0.0))
-        
+
         # bad Phaii class
         with self.assertRaises(TypeError):
             self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Pha)
-    
+
     def test_write(self):
         with self.assertRaises(NameError):
             self.tte.write('.')
@@ -258,40 +262,40 @@ class TestPhotonList(unittest.TestCase):
         tte1 = self.tte.slice_time((0.0, 5.0))
         tte2 = self.tte.slice_time((5.5, 11.0))
         tte = PhotonList.merge([tte1, tte2])
-        self.assertListEqual(tte.data.times.tolist(), 
+        self.assertListEqual(tte.data.times.tolist(),
                              self.tte.data.times.tolist())
-        self.assertListEqual(tte.data.channels.tolist(), 
+        self.assertListEqual(tte.data.channels.tolist(),
                              self.tte.data.channels.tolist())
         self.assertTupleEqual(tte.gti.as_list()[0], (0.706, 3.512))
         self.assertTupleEqual(tte.gti.as_list()[1], (5.54, 10.61))
-        
+
         # not a list of valid PhotonLists
         with self.assertRaises(ValueError):
             PhotonList.merge([tte1, tte2.gti])
-        
+
         # not a valid header index
         with self.assertRaises(ValueError):
             PhotonList.merge([tte1, tte2], primary=2)
-        
+
         eb = Ebounds.from_list(tte2.ebounds.as_list()[:-1])
         el = EventList(tte2.data.times, tte2.data.channels, ebounds=eb)
-        tte3 = PhotonList.from_data(el, gti=tte2.gti, 
+        tte3 = PhotonList.from_data(el, gti=tte2.gti,
                                     trigger_time=tte2.trigtime)
         with self.assertRaises(ValueError):
             PhotonList.merge([tte1, tte3])
-        
+
     def test_no_gti(self):
         tte = PhotonList.from_data(self.tte.data)
         self.assertTupleEqual(tte.gti.as_list()[0], (0.706, 10.61))
-    
+
     def test_errors(self):
-        
+
         with self.assertRaises(TypeError):
             PhotonList.from_data(self.tte.gti)
 
         with self.assertRaises(TypeError):
             PhotonList.from_data(self.tte.data, gti=self.tte.data)
-    
+
         with self.assertRaises(ValueError):
             PhotonList.from_data(self.tte.data, trigger_time=-10.0)
 
@@ -312,25 +316,25 @@ class TestPhotonList(unittest.TestCase):
 
 
 class TestPhotonListNoEbounds(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
-        times = [0.706, 1.640, 3.185, 3.512, 5.540, 
+        times = [0.706, 1.640, 3.185, 3.512, 5.540,
                  7.790, 9.602, 9.726, 10.45, 10.61]
         chans = [4, 1, 0, 4, 5, 0, 4, 0, 2, 0]
         data = EventList(times=times, channels=chans)
         gti = Gti.from_list([(0.0000, 10.70)])
-        cls.tte = PhotonList.from_data(data, gti=gti, 
+        cls.tte = PhotonList.from_data(data, gti=gti,
                                        trigger_time=356223561.133346,
-                                       event_deadtime=0.001, 
+                                       event_deadtime=0.001,
                                        overflow_deadtime=0.1)
-        
+
     def test_data(self):
         self.assertIsInstance(self.tte.data, EventList)
-    
+
     def test_ebounds(self):
         assert self.tte.ebounds is None
-    
+
     def test_energy_range(self):
         assert self.tte.energy_range is None
 
@@ -339,10 +343,10 @@ class TestPhotonListNoEbounds(unittest.TestCase):
 
     def test_filename(self):
         self.assertIsNone(self.tte.filename)
-    
+
     def test_gti(self):
         self.assertIsInstance(self.tte.gti, Gti)
-    
+
     def test_headers(self):
         self.assertIsNone(self.tte.headers)
 
@@ -351,17 +355,17 @@ class TestPhotonListNoEbounds(unittest.TestCase):
 
     def test_overflow_deadtime(self):
         self.assertEqual(self.tte.overflow_deadtime, 0.1)
-    
+
     def test_time_range(self):
         self.assertTupleEqual(self.tte.time_range, (0.706, 10.61))
-    
+
     def test_trigtime(self):
         self.assertEqual(self.tte.trigtime, 356223561.133346)
 
     def test_get_exposure(self):
         # total exposure
         self.assertAlmostEqual(self.tte.get_exposure(), 9.795)
-        
+
         # exposure of a time slice
         self.assertAlmostEqual(self.tte.get_exposure(time_ranges=(0.0, 5.0)),
                                4.996)
@@ -370,38 +374,38 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         self.assertAlmostEqual(self.tte.get_exposure(time_ranges=[(0.0, 2.0),
                                                                     (5.0, 7.0)]),
                                3.898)
-    
+
     def test_rebin_energy(self):
         # full range
         rebinned_tte = self.tte.rebin_energy(combine_by_factor, 2)
-        self.assertEqual(rebinned_tte.num_chans, 3)        
-        
+        self.assertEqual(rebinned_tte.num_chans, 3)
+
     def test_set_ebounds(self):
         emin = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
         emax = [20.0, 30.0, 40.0, 50.0, 60.0, 70.0]
         ebounds = Ebounds.from_bounds(emin, emax)
-        
-        data = EventList(times=self.tte.data.times, 
+
+        data = EventList(times=self.tte.data.times,
                          channels=self.tte.data.channels)
-        tte = PhotonList.from_data(data, gti=self.tte.gti, 
+        tte = PhotonList.from_data(data, gti=self.tte.gti,
                                    trigger_time=self.tte.trigtime,
                                    event_deadtime=self.tte.event_deadtime,
                                    overflow_deadtime=self.tte.overflow_deadtime)
-    
+
         with self.assertRaises(TypeError):
             tte.set_ebounds(emin)
-                
+
         tte.set_ebounds(ebounds)
         assert isinstance(tte.ebounds, Ebounds)
         self.assertListEqual(tte.ebounds.low_edges(), emin)
         self.assertListEqual(tte.ebounds.high_edges(), emax)
-    
+
     def test_slice_energy(self):
         # one slice
         sliced_tte = self.tte.slice_energy((2, 4))
         assert sliced_tte.energy_range is None
         self.assertEqual(sliced_tte.num_chans, 3)
-        
+
         # multiple slices
         sliced_tte = self.tte.slice_energy([(1, 2), (4, 5)])
         assert sliced_tte.energy_range is None
@@ -412,7 +416,7 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         sliced_tte = self.tte.slice_time((0.0, 5.0))
         self.assertTupleEqual(sliced_tte.time_range, (0.706, 3.512))
         self.assertEqual(sliced_tte.data.size, 4)
-        
+
         # multiple slices
         sliced_tte = self.tte.slice_time([(0.0, 2.0), (5.0, 7.0)])
         self.assertTupleEqual(sliced_tte.time_range, (0.706, 5.540))
@@ -423,25 +427,25 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         spec = self.tte.to_spectrum()
         self.assertIsInstance(spec, ChannelBins)
         self.assertTupleEqual(spec.range, (0, 5))
-        
+
         # this should be the whole range because we have no ebounds
         spec = self.tte.to_spectrum(energy_range=(50.0, 300.0))
         self.assertListEqual(spec.counts.tolist(), [4, 1, 1, 0, 3, 1])
-        
+
         # or channels
         spec = self.tte.to_spectrum(channel_range=(3, 5))
         self.assertListEqual(spec.counts.tolist(), [0, 0, 0, 0, 3, 1])
-        
+
         # integrate over a part of the time range
         spec = self.tte.to_spectrum(time_range=(0.0, 5.0))
         self.assertListEqual(spec.counts.tolist(), [1, 1, 0, 0, 2])
-    
+
     def test_to_pha(self):
-        
+
         # this should raise an exception
         with self.assertRaises(RuntimeError):
             self.tte.to_pha()
-        
+
     def test_to_phaii(self):
         # full range
         phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii)
@@ -451,9 +455,9 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         self.assertTupleEqual(phaii.time_range, (0.706, 10.706))
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 10)
-        
+
         # time range
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   time_range=(0.0, 5.0))
         assert phaii.energy_range is None
         self.assertTupleEqual(phaii.gti.as_list()[0], (0.706, 3.512))
@@ -461,9 +465,9 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         self.assertTupleEqual(phaii.time_range, (0.706, 3.706))
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 3)
-        
+
         # energy range (this should be same as full range because no ebounds)
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   energy_range=(10.0, 50.0))
         assert phaii.energy_range is None
         self.assertTupleEqual(phaii.gti.as_list()[0], self.tte.gti.as_list()[0])
@@ -472,28 +476,28 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         self.assertEqual(phaii.data.num_times, 10)
 
         # channel range
-        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+        phaii = self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                                   channel_range=(0, 2))
         assert phaii.energy_range is None
         self.assertTupleEqual(phaii.gti.as_list()[0], self.tte.gti.as_list()[0])
         self.assertEqual(phaii.num_chans, 3)
         self.assertEqual(phaii.trigtime, self.tte.trigtime)
         self.assertEqual(phaii.data.num_times, 9)
-        
+
         # bad time range
         with self.assertRaises(AssertionError):
-            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                               time_range=(1.0, 0.0))
-       
+
         # bad channel range
         with self.assertRaises(AssertionError):
-            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii, 
+            self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Phaii,
                               channel_range=(1.0, 0.0))
-        
+
         # bad Phaii class
         with self.assertRaises(TypeError):
             self.tte.to_phaii(bin_by_time, 1.0, phaii_class=Pha)
-    
+
     def test_write(self):
         with self.assertRaises(NameError):
             self.tte.write('.')
@@ -502,33 +506,33 @@ class TestPhotonListNoEbounds(unittest.TestCase):
         tte1 = self.tte.slice_time((0.0, 5.0))
         tte2 = self.tte.slice_time((6.0, 10.0))
         tte = PhotonList.merge([tte1, tte2])
-        self.assertListEqual(tte.data.times.tolist(), 
+        self.assertListEqual(tte.data.times.tolist(),
                              [0.706, 1.640, 3.185, 3.512, 7.790, 9.602, 9.726])
-        self.assertListEqual(tte.data.channels.tolist(), 
+        self.assertListEqual(tte.data.channels.tolist(),
                              [4, 1, 0, 4, 0, 4, 0])
         self.assertTupleEqual(tte.gti.as_list()[0], (0.706, 3.512))
         self.assertTupleEqual(tte.gti.as_list()[1], (7.79, 9.726))
-        
+
         # not a list of valid PhotonLists
         with self.assertRaises(ValueError):
             PhotonList.merge([tte1, tte2.gti])
-        
+
         # not a valid header index
         with self.assertRaises(ValueError):
             PhotonList.merge([tte1, tte2], primary=2)
-                
+
     def test_no_gti(self):
         tte = PhotonList.from_data(self.tte.data)
         self.assertTupleEqual(tte.gti.as_list()[0], (0.706, 10.61))
-    
+
     def test_errors(self):
-        
+
         with self.assertRaises(TypeError):
             PhotonList.from_data(self.tte.gti)
 
         with self.assertRaises(TypeError):
             PhotonList.from_data(self.tte.data, gti=self.tte.data)
-    
+
         with self.assertRaises(ValueError):
             PhotonList.from_data(self.tte.data, trigger_time=-10.0)
 
@@ -546,8 +550,8 @@ class TestPhotonListNoEbounds(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             PhotonList.from_data(self.tte.data, overflow_deadtime='')
-                    
-                
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
The `PhotonList.to_phaii()` method should apply the `PhotonList.event_deadtime` and `PhotonList.overflow_deadtime` when calculating the exposure.  Currently, assumes the default, `event_deadtime=2.6e-6` and `overflow_deadtime=1.5e-5`, which happen to be the deadtime values for Fermi GBM.  

This PR fixes this by applying the deadtime values defined in the object and adds a unit test to ensure that the deadtime is correctly applied and the exposure is correct.