### PR TITLE
Fix for TypeError when using GDT plotting

### DIFF
--- a/src/gdt/core/plot/plot.py
+++ b/src/gdt/core/plot/plot.py
@@ -1762,6 +1762,10 @@ class DetectorPointing(SkyCircle):
         self._fontsize = size
 
     def _annotate(self, x, y, ax, flipped, frame):
+        # Need to demote (1,) arrays into scalars
+        x = x[0] if isinstance(x, np.ndarray) and x.shape == (1,) else x
+        y = y[0] if isinstance(y, np.ndarray) and y.shape == (1,) else y
+
         theta = np.deg2rad(y)
         phi = np.deg2rad(180.0 - x)
         if frame == 'spacecraft':


### PR DESCRIPTION
Latest version of NumPy throws the following exception when using the plot functions in GDT:
TypeError: only 0-dimensional arrays can be converted to Python scalars

This is fixed by demoting (1,) numpy arrays into a scalar prior to passing to to Matplotlib's Text() function. 