### PR TITLE
Return paths of downloaded files from FileDownloader

### DIFF
--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -802,11 +802,14 @@ class FileDownloader(AbstractContextManager):
             dest_dir (str, Path): The directory where the file will be written
             verbose (bool, optional): If True, will output the download status.
                                       Default is True.
+
+        Returns:
+            (Path)
         """
         if url.startswith('ftp'):
-            self._ftp.download_url(url, dest_dir, verbose)
+            return self._ftp.download_url(url, dest_dir, verbose)
         elif url.startswith('http'):
-            self._http.download_url(url, dest_dir, verbose)
+            return self._http.download_url(url, dest_dir, verbose)
         else:
             raise ValueError('url must begin with ftp://, http://, or https://')
 
@@ -818,10 +821,14 @@ class FileDownloader(AbstractContextManager):
             dest_dir (str, Path): The directory where the file will be written
             verbose (bool, optional): If True, will output the download status.
                                       Default is True.
-        """
-        for url in urls:
-            self.download_url(url, dest_dir, verbose)
 
+        Returns:
+            (list): File path list
+        """
+        files = []
+        for url in urls:
+            files.append(self.download_url(url, dest_dir, verbose))
+        return files
 
 class BrowseCatalog:
     """A class that interfaces with the HEASARC Browse API.  This can be


### PR DESCRIPTION
I'd like to update the FileDownloader class to return the list of paths for downloaded files.

This is useful in cases where the user wants to manipulate the file after download. For instance, with the generalized targeted search we want to download and untar the response templates with a loop like this:

```
with FileDownloader() as dload:
    files = dload.bulk_download(urls, dest_dir)
    for f in files:
        if ".tar" in f.suffixes: 
            tar = tarfile.open(f)
            tar.extractall(dest_dir)
```

This change will make the basic FileDownloader behavior consistent with the Finder classes since those already return the list of downloaded files.