### PR TITLE
AWS Finder: Throw an exception if the path is invalid

### DIFF
--- a/src/gdt/core/heasarc.py
+++ b/src/gdt/core/heasarc.py
@@ -236,6 +236,7 @@ class BaseProtocol(AbstractContextManager, ABC, ProgressMixin):
         """(bool): True if the protocol has been initialized"""
         pass
 
+
 class Ftp(BaseProtocol):
     """A class for FTP interactions with a remote archive.
     
@@ -595,6 +596,11 @@ class Aws(Http):
 
         super().__init__(url, start_key, end_key, table_key, progress, context, timeout)
 
+    def _cd(self, path: str):
+        super()._cd(path)
+        if len(self._ls(path)) == 0:
+            raise ValueError(f'{path} is not a valid path')
+    
     def _ls(self, path: str):
         """List the directory contents of an AWS directory associated with
         a data set.
@@ -829,6 +835,7 @@ class FileDownloader(AbstractContextManager):
         for url in urls:
             files.append(self.download_url(url, dest_dir, verbose))
         return files
+
 
 class BrowseCatalog:
     """A class that interfaces with the HEASARC Browse API.  This can be


### PR DESCRIPTION
This small update will throw an error if the AWS S3 path is invalid, consistent with what the FTP and HTTPS protocols do.  An S3 path does not have native error handling in the same way that FTP and HTTPS do, so this checks if any files exist at the proposed path.  If no files exist, then the path is not valid.

Valid path:
```python
finder = TriggerFinder('251005671', protocol='AWS')
finder.num_files
```
```
122
```

Invalid path:
```python
finder = TriggerFinder('2501005671', protocol='AWS')
```
```pytb
ValueError: /fermi/data/gbm/triggers/2025/bn2501005671/current is not a valid path
```

This more generally addresses the issue in https://github.com/USRA-STI/gdt-fermi/issues/71.